### PR TITLE
Fix a number error in doc: oss.Bucket.List

### DIFF
--- a/oss/client.go
+++ b/oss/client.go
@@ -655,7 +655,7 @@ type Key struct {
 // will return keys alphabetically greater than the marker.
 //
 // The max parameter specifies how many keys + common prefixes to return in
-// the response. The default is 1000.
+// the response, at most 1000. The default is 100.
 //
 // For example, given these keys in a bucket:
 //


### PR DESCRIPTION
https://docs.aliyun.com/#/pub/oss/api-reference/bucket&GetBucket 
文档写的是“限定此次返回object的最大数，如果不设定，默认为100，max-keys取值不能大于1000。”，代码里的注释写错了。

@denverdino Plz review, thx!