### PR TITLE
add APIError Interface

### DIFF
--- a/common/request.go
+++ b/common/request.go
@@ -41,6 +41,30 @@ func (request *Request) init(version string, action string, AccessKeyId string) 
 	request.AccessKeyId = AccessKeyId
 }
 
+type APIError interface {
+	GetCode() string
+	GetHostId() string
+	GetMessage() string
+	GetResponseId() string
+	Error() string
+}
+
+func (e *Error) GetCode() string {
+	return e.Code
+}
+
+func (e *Error) GetHostId() string {
+	return e.HostId
+}
+
+func (e *Error) GetMessage() string {
+	return e.Message
+}
+
+func (e *Error) GetResponseId() string {
+	return e.RequestId
+}
+
 type Response struct {
 	RequestId string
 }


### PR DESCRIPTION
添加APIError接口。以便在后续对于错误判断的时候可以方便的进行类型断言。
Demo

err := xxx
apiErr ,ok := err.(common.Error)
if ok {
     //如果类型断言成功，则可以获取Error结构中的内容
}

