### PR TITLE
fix ecs.LockReason unmarshal error

### DIFF
--- a/ecs/instances.go
+++ b/ecs/instances.go
@@ -22,12 +22,9 @@ const (
 	Stopping = InstanceStatus("Stopping")
 )
 
-type LockReason string
-
-const (
-	LockReasonFinancial = LockReason("financial")
-	LockReasonSecurity  = LockReason("security")
-)
+type LockReason struct {
+	LockReason string
+}
 
 type DescribeInstanceStatusArgs struct {
 	RegionId common.Region


### PR DESCRIPTION
fix #52

remove const `ecs.LockReasonFinancial`, `ecs.LockReasonSecurity` because ecs.LockReason  is struct type now.