### PR TITLE
add InstanceName for search request

### DIFF
--- a/ecs/instances.go
+++ b/ecs/instances.go
@@ -307,6 +307,7 @@ type DescribeInstancesArgs struct {
 	ZoneId              string
 	InstanceIds         string
 	InstanceNetworkType string
+	InstanceName        string
 	PrivateIpAddresses  string
 	InnerIpAddresses    string
 	PublicIpAddresses   string


### PR DESCRIPTION
When my app run in one aliyun instance, my app want to get the InstanceID of this instance, so I want to `DescribeInstances` by `RegionId` and `InstanceName`. The `InstanceName` is the `hostname`   of the local instance.  
This is why I add `InstanceName` in `DescribeInstancesArgs` struct.