### PR TITLE
Added STS support with unit tests

### DIFF
--- a/oss/client.go
+++ b/oss/client.go
@@ -996,7 +996,7 @@ func (client *Client) prepare(req *request) error {
 	// Copy so they can be mutated without affecting on retries.
 	headers := copyHeader(req.headers)
 	if len(client.SecurityToken) != 0 {
-		headers["x-oss-security-token"] = []string{client.SecurityToken}
+		headers.Set("x-oss-security-token", client.SecurityToken)
 	}
 
 	params := make(url.Values)

--- a/oss/client.go
+++ b/oss/client.go
@@ -32,6 +32,7 @@ const DefaultContentType = "application/octet-stream"
 type Client struct {
 	AccessKeyId     string
 	AccessKeySecret string
+	SecurityToken   string
 	Region          Region
 	Internal        bool
 	Secure          bool
@@ -86,6 +87,18 @@ var attempts = util.AttemptStrategy{
 }
 
 // NewOSSClient creates a new OSS.
+
+func NewOSSClientForAssumeRole(region Region, internal bool, accessKeyId string, accessKeySecret string, securityToken string, secure bool) *Client {
+	return &Client{
+		AccessKeyId:     accessKeyId,
+		AccessKeySecret: accessKeySecret,
+		SecurityToken:   securityToken,
+		Region:          region,
+		Internal:        internal,
+		debug:           false,
+		Secure:          secure,
+	}
+}
 
 func NewOSSClient(region Region, internal bool, accessKeyId string, accessKeySecret string, secure bool) *Client {
 	return &Client{
@@ -982,6 +995,10 @@ func partiallyEscapedPath(path string) string {
 func (client *Client) prepare(req *request) error {
 	// Copy so they can be mutated without affecting on retries.
 	headers := copyHeader(req.headers)
+	if len(client.SecurityToken) != 0 {
+		headers["x-oss-security-token"] = []string{client.SecurityToken}
+	}
+
 	params := make(url.Values)
 
 	for k, v := range req.params {

--- a/oss/signature.go
+++ b/oss/signature.go
@@ -99,7 +99,8 @@ func canonicalizeHeader(headers http.Header) (newHeaders http.Header, result str
 	var canonicalizedHeader string
 
 	for _, k := range canonicalizedHeaders {
-		canonicalizedHeader += k + ":" + headers.Get(k) + "\n"
+		canonicalizedHeader += k + ":" + headers[k][0] + "\n"
 	}
+
 	return newHeaders, canonicalizedHeader
 }

--- a/oss/signature.go
+++ b/oss/signature.go
@@ -99,7 +99,7 @@ func canonicalizeHeader(headers http.Header) (newHeaders http.Header, result str
 	var canonicalizedHeader string
 
 	for _, k := range canonicalizedHeaders {
-		canonicalizedHeader += k + ":" + headers[k][0] + "\n"
+		canonicalizedHeader += k + ":" + headers.Get(k) + "\n"
 	}
 
 	return newHeaders, canonicalizedHeader

--- a/sts/assume_role.go
+++ b/sts/assume_role.go
@@ -1,0 +1,37 @@
+package sts
+
+import "github.com/denverdino/aliyungo/common"
+
+type AssumeRoleRequest struct {
+	RoleArn         string
+	RoleSessionName string
+	DurationSeconds int
+	Policy          string
+}
+
+type AssumedRoleUser struct {
+	AssumedRoleId string
+	Arn           string
+}
+
+type AssumedRoleUserCredentials struct {
+	AccessKeySecret string
+	AccessKeyId     string
+	Expiration      string
+	SecurityToken   string
+}
+
+type AssumeRoleResponse struct {
+	common.Response
+	AssumedRoleUser AssumedRoleUser
+	Credentials     AssumedRoleUserCredentials
+}
+
+func (c *STSClient) AssumeRole(r AssumeRoleRequest) (AssumeRoleResponse, error) {
+	resp := AssumeRoleResponse{}
+	e := c.Invoke("AssumeRole", r, &resp)
+	if e != nil {
+		return AssumeRoleResponse{}, e
+	}
+	return resp, nil
+}

--- a/sts/assume_role_test.go
+++ b/sts/assume_role_test.go
@@ -1,0 +1,141 @@
+package sts
+
+import (
+	"encoding/json"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/denverdino/aliyungo/ram"
+)
+
+/*
+  Please also set account id in env so that roles could be created test
+	 AccessKeyId=YourAccessKeyId AccessKeySecret=YourAccessKeySecret AccountId=111111111 go test -v -run=AssumeRole
+*/
+var (
+	accountId = os.Getenv("AccountId")
+	roleName  = strconv.FormatInt(time.Now().Unix(), 10)
+
+	princpal = ram.AssumeRolePolicyPrincpal{RAM: []string{"acs:ram::" + accountId + ":root"}}
+
+	princpalPolicyDocument = ram.AssumeRolePolicyDocument{
+		Statement: []ram.AssumeRolePolicyItem{
+			ram.AssumeRolePolicyItem{Action: "sts:AssumeRole", Effect: "Allow", Principal: princpal},
+		},
+		Version: "1"}
+
+	role = ram.RoleRequest{
+		RoleName:                 roleName,
+		AssumeRolePolicyDocument: getAssumeRolePolicyDocumentStr(),
+		Description:              "this is a role for unit test purpose",
+	}
+)
+
+var policyDocument = ram.PolicyDocument{
+	Statement: []ram.PolicyItem{
+		ram.PolicyItem{
+			Action:   "oss:GetObject",
+			Effect:   "Allow",
+			Resource: "acs:oss:*:*:*/anyprefix",
+		},
+	},
+	Version: "1",
+}
+
+func getAssumeRolePolicyDocumentStr() string {
+	b, _ := json.Marshal(princpalPolicyDocument)
+	return string(b)
+}
+
+func createAssumeRoleRequest(roleArn string) AssumeRoleRequest {
+	document, _ := json.Marshal(policyDocument)
+	return AssumeRoleRequest{
+		RoleArn:         roleArn,
+		RoleSessionName: "aliyungo-sts-unit-test",
+		DurationSeconds: 3600,
+		Policy:          string(document),
+	}
+}
+
+func createPolicyDocument() *ram.PolicyDocument {
+	return &ram.PolicyDocument{
+		Statement: []ram.PolicyItem{
+			ram.PolicyItem{
+				Action:   "oss:GetObject",
+				Effect:   "Allow",
+				Resource: "acs:oss:*:*:*/*",
+			},
+		},
+		Version: "1",
+	}
+}
+
+func createPolicyReq() *ram.PolicyRequest {
+	policyDocument := createPolicyDocument()
+	document, _ := json.Marshal(*policyDocument)
+	return &ram.PolicyRequest{
+		PolicyName:     "sts-" + strconv.FormatInt(time.Now().Unix(), 10),
+		PolicyType:     "Custom",
+		PolicyDocument: string(document),
+	}
+}
+
+func TestAssumeRole(t *testing.T) {
+
+	//
+	//1. create a role
+	//
+	ramClient := NewRAMTestClient()
+	roleResp, err := ramClient.CreateRole(role)
+	if err != nil {
+		t.Errorf("Failed to CreateRole %v", err)
+		return
+	}
+
+	//
+	//2. create a policy to have the access to oss
+	//
+	policyResp, err := ramClient.CreatePolicy(*createPolicyReq())
+	if err != nil {
+		t.Errorf("Failed to CreatePolicy %v", err)
+		return
+	}
+
+	//
+	//2. attach a policy to this role
+	//
+	attachPolicyRequest := ram.AttachPolicyToRoleRequest{
+		PolicyRequest: ram.PolicyRequest{
+			PolicyType: "Custom",
+			PolicyName: policyResp.Policy.PolicyName,
+		},
+		RoleName: roleResp.Role.RoleName,
+	}
+
+	_, err = ramClient.AttachPolicyToRole(attachPolicyRequest)
+	if err != nil {
+		t.Errorf("Failed to AttachPolicyToRole %v", err)
+		return
+	}
+
+	//
+	//CAUTION: Aliyun right now have a bug, once a role is created, if you assume this role immediately, it will always fail.
+	//				You have to sleep for several seconds to work around this problem
+	//
+	time.Sleep(2 * time.Second)
+
+	//
+	//3. assume this role
+	//
+	client := NewTestClient()
+	req := createAssumeRoleRequest(roleResp.Role.Arn)
+	resp, err := client.AssumeRole(req)
+	if err != nil {
+		t.Errorf("Failed to AssumeRole %v", err)
+		return
+	}
+	t.Logf("pass AssumeRole %v", resp)
+
+}

--- a/sts/client.go
+++ b/sts/client.go
@@ -1,0 +1,31 @@
+package sts
+
+import (
+	"os"
+
+	"github.com/denverdino/aliyungo/common"
+)
+
+const (
+	// STSDefaultEndpoint is the default API endpoint of STS services
+	STSDefaultEndpoint = "https://sts.aliyuncs.com"
+	STSAPIVersion      = "2015-04-01"
+)
+
+type STSClient struct {
+	common.Client
+}
+
+func NewClient(accessKeyId string, accessKeySecret string) *STSClient {
+	endpoint := os.Getenv("STS_ENDPOINT")
+	if endpoint == "" {
+		endpoint = STSDefaultEndpoint
+	}
+	return NewClientWithEndpoint(endpoint, accessKeyId, accessKeySecret)
+}
+
+func NewClientWithEndpoint(endpoint string, accessKeyId string, accessKeySecret string) *STSClient {
+	client := &STSClient{}
+	client.Init(endpoint, STSAPIVersion, accessKeyId, accessKeySecret)
+	return client
+}

--- a/sts/client_test.go
+++ b/sts/client_test.go
@@ -1,0 +1,28 @@
+package sts
+
+import (
+	"os"
+
+	"github.com/denverdino/aliyungo/ram"
+)
+
+/*
+	Set your AccessKeyId and AccessKeySecret in env
+	simply use the command below
+	AccessKeyId=YourAccessKeyId AccessKeySecret=YourAccessKeySecret go test
+*/
+var (
+	AccessKeyId     = os.Getenv("AccessKeyId")
+	AccessKeySecret = os.Getenv("AccessKeySecret")
+)
+
+func NewRAMTestClient() ram.RamClientInterface {
+	client := ram.NewClient(AccessKeyId, AccessKeySecret)
+	return client
+}
+
+func NewTestClient() *STSClient {
+	client := NewClient(AccessKeyId, AccessKeySecret)
+	//client.SetDebug(true)
+	return client
+}


### PR DESCRIPTION
1. STS support itself with unit tests
2. light Integration with oss client. I had a test locally:
    a. create a role for assume which only has oss:GetObject prolicy attached
    b. assume this role with object prefix policy
    c. files could be downloaded successfully


Once again, any comments is welcomed and let me know if you think any further modification in this pull request is required, thanks!