### PR TITLE
Add vpc metadata client support

### DIFF
--- a/metadata/client.go
+++ b/metadata/client.go
@@ -1,0 +1,344 @@
+package metadata
+
+import (
+	"errors"
+	"fmt"
+	"github.com/denverdino/aliyungo/util"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+type Request struct {
+}
+
+const (
+	ENDPOINT = "http://100.100.100.200"
+
+	META_VERSION_LATEST = "latest"
+
+	RS_TYPE_META_DATA = "meta-data"
+	RS_TYPE_USER_DATA = "user-data"
+
+	DNS_NAMESERVERS    = "dns-conf/nameservers"
+	EIPV4              = "eipv4"
+	HOSTNAME           = "hostname"
+	IMAGE_ID           = "image-id"
+	INSTANCE_ID        = "instance-id"
+	MAC                = "mac"
+	NETWORK_TYPE       = "network-type"
+	NTP_CONF_SERVERS   = "ntp-conf/ntp-servers"
+	OWNER_ACCOUNT_ID   = "owner-account-id"
+	PRIVATE_IPV4       = "private-ipv4"
+	REGION             = "region-id"
+	SERIAL_NUMBER      = "serial-number"
+	SOURCE_ADDRESS     = "source-address"
+	VPC_CIDR_BLOCK     = "vpc-cidr-block"
+	VPC_ID             = "vpc-id"
+	VSWITCH_CIDR_BLOCK = "vswitch-cidr-block"
+	VSWITCH_ID         = "vswitch-id"
+)
+
+type IMetaDataClient interface {
+	Version(version string) IMetaDataClient
+	ResourceType(rtype string) IMetaDataClient
+	Resource(resource string) IMetaDataClient
+	Go() ([]string, error)
+	Url() (string, error)
+}
+
+type MetaData struct {
+	c IMetaDataClient
+}
+
+func NewMetaData(client *http.Client) *MetaData {
+	if client == nil {
+		client = &http.Client{}
+	}
+	return &MetaData{
+		c: &MetaDataClient{client: client},
+	}
+}
+
+func (m *MetaData) HostName() (string, error) {
+
+	hostname, err := m.c.Resource(HOSTNAME).Go()
+	if err != nil {
+		return "", err
+	}
+	return hostname[0], nil
+}
+
+func (m *MetaData) ImageID() (string, error) {
+
+	image, err := m.c.Resource(IMAGE_ID).Go()
+	if err != nil {
+		return "", err
+	}
+	return image[0], err
+}
+
+func (m *MetaData) InstanceID() (string, error) {
+
+	instanceid, err := m.c.Resource(INSTANCE_ID).Go()
+	if err != nil {
+		return "", err
+	}
+	return instanceid[0], err
+}
+
+func (m *MetaData) Mac() (string, error) {
+
+	mac, err := m.c.Resource(MAC).Go()
+	if err != nil {
+		return "", err
+	}
+	return mac[0], nil
+}
+
+func (m *MetaData) NetworkType() (string, error) {
+
+	network, err := m.c.Resource(NETWORK_TYPE).Go()
+	if err != nil {
+		return "", err
+	}
+	return network[0], nil
+}
+
+func (m *MetaData) OwnerAccountID() (string, error) {
+
+	owner, err := m.c.Resource(OWNER_ACCOUNT_ID).Go()
+	if err != nil {
+		return "", err
+	}
+	return owner[0], nil
+}
+
+func (m *MetaData) PrivateIPv4() (string, error) {
+
+	private, err := m.c.Resource(PRIVATE_IPV4).Go()
+	if err != nil {
+		return "", err
+	}
+	return private[0], nil
+}
+
+func (m *MetaData) Region() (string, error) {
+
+	region, err := m.c.Resource(REGION).Go()
+	if err != nil {
+		return "", err
+	}
+	return region[0], nil
+}
+
+func (m *MetaData) SerialNumber() (string, error) {
+
+	serial, err := m.c.Resource(SERIAL_NUMBER).Go()
+	if err != nil {
+		return "", err
+	}
+	return serial[0], nil
+}
+
+func (m *MetaData) SourceAddress() (string, error) {
+
+	source, err := m.c.Resource(SOURCE_ADDRESS).Go()
+	if err != nil {
+		return "", err
+	}
+	return source[0], nil
+
+}
+
+func (m *MetaData) VpcCIDRBlock() (string, error) {
+
+	vpcCIDR, err := m.c.Resource(VPC_CIDR_BLOCK).Go()
+	if err != nil {
+		return "", err
+	}
+	return vpcCIDR[0], err
+}
+
+func (m *MetaData) VpcID() (string, error) {
+
+	vpcId, err := m.c.Resource(VPC_ID).Go()
+	if err != nil {
+		return "", err
+	}
+	return vpcId[0], err
+}
+
+func (m *MetaData) VswitchCIDRBlock() (string, error) {
+
+	cidr, err := m.c.Resource(VSWITCH_CIDR_BLOCK).Go()
+	if err != nil {
+		return "", err
+	}
+	return cidr[0], err
+}
+
+func (m *MetaData) VswitchID() (string, error) {
+
+	vswithcid, err := m.c.Resource(VSWITCH_ID).Go()
+	if err != nil {
+		return "", err
+	}
+	return vswithcid[0], err
+}
+
+func (m *MetaData) EIPv4() (string, error) {
+
+	eip, err := m.c.Resource(EIPV4).Go()
+	if err != nil {
+		return "", err
+	}
+	return eip[0], nil
+}
+
+func (m *MetaData) DNSNameServers() ([]string, error) {
+
+	data, err := m.c.Resource(DNS_NAMESERVERS).Go()
+	if err != nil {
+		return []string{}, err
+	}
+	return data, nil
+}
+
+func (m *MetaData) NTPConfigServers() ([]string, error) {
+
+	data, err := m.c.Resource(NTP_CONF_SERVERS).Go()
+	if err != nil {
+		return []string{}, err
+	}
+	return data, nil
+}
+
+//
+type MetaDataClient struct {
+	version      string
+	resourceType string
+	resource     string
+	client       *http.Client
+}
+
+func (vpc *MetaDataClient) Version(version string) IMetaDataClient {
+	vpc.version = version
+	return vpc
+}
+
+func (vpc *MetaDataClient) ResourceType(rtype string) IMetaDataClient {
+	vpc.resourceType = rtype
+	return vpc
+}
+
+func (vpc *MetaDataClient) Resource(resource string) IMetaDataClient {
+	vpc.resource = resource
+	return vpc
+}
+
+var retry = util.AttemptStrategy{
+	Min:   5,
+	Total: 5 * time.Second,
+	Delay: 200 * time.Millisecond,
+}
+
+func (vpc *MetaDataClient) Url() (string, error) {
+	if vpc.version == "" {
+		vpc.version = "latest"
+	}
+	if vpc.resourceType == "" {
+		vpc.resourceType = "meta-data"
+	}
+	if vpc.resource == "" {
+		return "", errors.New("the resource you want to visit must not be nil!")
+	}
+	return fmt.Sprintf("%s/%s/%s/%s", ENDPOINT, vpc.version, vpc.resourceType, vpc.resource), nil
+}
+
+func (vpc *MetaDataClient) Go() (resu []string, err error) {
+	for r := retry.Start(); r.Next(); {
+		resu, err = vpc.send()
+		if !shouldRetry(err) {
+			break
+		}
+	}
+	return resu, err
+}
+
+func (vpc *MetaDataClient) send() ([]string, error) {
+	url, err := vpc.Url()
+	if err != nil {
+		return []string{}, err
+	}
+	requ, err := http.NewRequest(http.MethodGet, url, nil)
+
+	if err != nil {
+		return []string{}, err
+	}
+	resp, err := vpc.client.Do(requ)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != 200 {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return []string{}, err
+	}
+	if string(data) == "" {
+		return []string{""}, nil
+	}
+	return strings.Split(string(data), "\n"), nil
+}
+
+type TimeoutError interface {
+	error
+	Timeout() bool // Is the error a timeout?
+}
+
+func shouldRetry(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	_, ok := err.(TimeoutError)
+	if ok {
+		return true
+	}
+
+	switch err {
+	case io.ErrUnexpectedEOF, io.EOF:
+		return true
+	}
+	switch e := err.(type) {
+	case *net.DNSError:
+		return true
+	case *net.OpError:
+		switch e.Op {
+		case "read", "write":
+			return true
+		}
+	case *url.Error:
+		// url.Error can be returned either by net/url if a URL cannot be
+		// parsed, or by net/http if the response is closed before the headers
+		// are received or parsed correctly. In that later case, e.Op is set to
+		// the HTTP method name with the first letter uppercased. We don't want
+		// to retry on POST operations, since those are not idempotent, all the
+		// other ones should be safe to retry.
+		switch e.Op {
+		case "Get", "Put", "Delete", "Head":
+			return shouldRetry(e.Err)
+		default:
+			return false
+		}
+	}
+	return false
+}

--- a/metadata/client_test.go
+++ b/metadata/client_test.go
@@ -1,0 +1,307 @@
+package metadata
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func init() {
+	fmt.Println("make sure your ecs is in vpc before you run ```go test```")
+}
+
+type MockMetaDataClient struct {
+	I IMetaDataClient
+}
+
+func (vpc *MockMetaDataClient) Version(version string) IMetaDataClient {
+	vpc.I.Version(version)
+	return vpc
+}
+
+func (vpc *MockMetaDataClient) ResourceType(rtype string) IMetaDataClient {
+	vpc.I.ResourceType(rtype)
+	return vpc
+}
+
+func (vpc *MockMetaDataClient) Resource(resource string) IMetaDataClient {
+	vpc.I.Resource(resource)
+	return vpc
+}
+
+func (vpc *MockMetaDataClient) Url() (string, error) {
+	return vpc.I.Url()
+}
+
+func (m *MockMetaDataClient) Go() ([]string, error) {
+	uri, err := m.Url()
+	if err != nil {
+		return []string{}, errors.New("error retrieve url")
+	}
+	if strings.Contains(uri, HOSTNAME) {
+		return []string{"hostname-test"}, nil
+	}
+
+	if strings.Contains(uri, DNS_NAMESERVERS) {
+		return []string{"8.8.8.8", "8.8.4.4"}, nil
+	}
+
+	if strings.Contains(uri, EIPV4) {
+		return []string{"1.1.1.1-test"}, nil
+	}
+
+	if strings.Contains(uri, IMAGE_ID) {
+		return []string{"image-id-test"}, nil
+	}
+
+	if strings.Contains(uri, INSTANCE_ID) {
+		return []string{"instanceid-test"}, nil
+	}
+
+	if strings.Contains(uri, MAC) {
+		return []string{"mac-test"}, nil
+	}
+
+	if strings.Contains(uri, NETWORK_TYPE) {
+		return []string{"network-type-test"}, nil
+	}
+
+	if strings.Contains(uri, OWNER_ACCOUNT_ID) {
+		return []string{"owner-account-id-test"}, nil
+	}
+
+	if strings.Contains(uri, PRIVATE_IPV4) {
+		return []string{"private-ipv4-test"}, nil
+	}
+
+	if strings.Contains(uri, REGION) {
+		return []string{"region-test"}, nil
+	}
+
+	if strings.Contains(uri, SERIAL_NUMBER) {
+		return []string{"serial-number-test"}, nil
+	}
+
+	if strings.Contains(uri, SOURCE_ADDRESS) {
+		return []string{"source-address-test"}, nil
+	}
+
+	if strings.Contains(uri, VPC_CIDR_BLOCK) {
+		return []string{"vpc-cidr-block-test"}, nil
+	}
+
+	if strings.Contains(uri, VPC_ID) {
+		return []string{"vpc-id-test"}, nil
+	}
+
+	if strings.Contains(uri, VSWITCH_CIDR_BLOCK) {
+		return []string{"vswitch-cidr-block-test"}, nil
+	}
+
+	if strings.Contains(uri, VSWITCH_ID) {
+		return []string{"vswitch-id-test"}, nil
+	}
+
+	if strings.Contains(uri, NTP_CONF_SERVERS) {
+		return []string{"ntp1.server.com", "ntp2.server.com"}, nil
+	}
+
+	return nil, errors.New("unknow resource error.")
+}
+
+func TestOK(t *testing.T) {
+	fmt.Println("ok")
+}
+
+func NewMockMetaData(client *http.Client) *MetaData {
+	if client == nil {
+		client = &http.Client{}
+	}
+	return &MetaData{
+		c: &MetaDataClient{client: client},
+	}
+}
+
+//func NewMockMetaData(client *http.Client)* MetaData{
+//	if client == nil {
+//		client = &http.Client{}
+//	}
+//	return &MetaData{
+//		c: &MockMetaDataClient{&MetaDataClient{client:client}},
+//	}
+//}
+
+func TestHostname(t *testing.T) {
+	meta := NewMockMetaData(nil)
+	host, err := meta.HostName()
+	if err != nil {
+		t.Errorf("hostname err: %s", err.Error())
+	}
+	if host != "hostname-test" {
+		t.Error("hostname not equal hostname-test")
+	}
+}
+
+func TestEIPV4(t *testing.T) {
+	meta := NewMockMetaData(nil)
+	host, err := meta.EIPv4()
+	if err != nil {
+		t.Errorf("EIPV4 err: %s", err.Error())
+	}
+	if host != "1.1.1.1-test" {
+		t.Error("EIPV4 not equal eipv4-test")
+	}
+}
+func TestImageID(t *testing.T) {
+	meta := NewMockMetaData(nil)
+	host, err := meta.ImageID()
+	if err != nil {
+		t.Errorf("IMAGE_ID err: %s", err.Error())
+	}
+	if host != "image-id-test" {
+		t.Error("IMAGE_ID not equal image-id-test")
+	}
+}
+func TestInstanceID(t *testing.T) {
+	meta := NewMockMetaData(nil)
+	host, err := meta.InstanceID()
+	if err != nil {
+		t.Errorf("IMAGE_ID err: %s", err.Error())
+	}
+	if host != "instanceid-test" {
+		t.Error("IMAGE_ID not equal instanceid-test")
+	}
+}
+func TestMac(t *testing.T) {
+	meta := NewMockMetaData(nil)
+	host, err := meta.Mac()
+	if err != nil {
+		t.Errorf("Mac err: %s", err.Error())
+	}
+	if host != "mac-test" {
+		t.Error("Mac not equal mac-test")
+	}
+}
+func TestNetworkType(t *testing.T) {
+	meta := NewMockMetaData(nil)
+	host, err := meta.NetworkType()
+	if err != nil {
+		t.Errorf("NetworkType err: %s", err.Error())
+	}
+	if host != "network-type-test" {
+		t.Error("networktype not equal network-type-test")
+	}
+}
+func TestOwnerAccountID(t *testing.T) {
+	meta := NewMockMetaData(nil)
+	host, err := meta.OwnerAccountID()
+	if err != nil {
+		t.Errorf("owneraccountid err: %s", err.Error())
+	}
+	if host != "owner-account-id-test" {
+		t.Error("owner-account-id not equal owner-account-id-test")
+	}
+}
+func TestPrivateIPv4(t *testing.T) {
+	meta := NewMockMetaData(nil)
+	host, err := meta.PrivateIPv4()
+	if err != nil {
+		t.Errorf("privateIPv4 err: %s", err.Error())
+	}
+	if host != "private-ipv4-test" {
+		t.Error("privateIPv4 not equal private-ipv4-test")
+	}
+}
+func TestRegion(t *testing.T) {
+	meta := NewMockMetaData(nil)
+	host, err := meta.Region()
+	if err != nil {
+		t.Errorf("region err: %s", err.Error())
+	}
+	if host != "region-test" {
+		t.Error("region not equal region-test")
+	}
+}
+func TestSerialNumber(t *testing.T) {
+	meta := NewMockMetaData(nil)
+	host, err := meta.SerialNumber()
+	if err != nil {
+		t.Errorf("serial number err: %s", err.Error())
+	}
+	if host != "serial-number-test" {
+		t.Error("serial number not equal serial-number-test")
+	}
+}
+
+func TestSourceAddress(t *testing.T) {
+	meta := NewMockMetaData(nil)
+	host, err := meta.SourceAddress()
+	if err != nil {
+		t.Errorf("source address err: %s", err.Error())
+	}
+	if host != "source-address-test" {
+		t.Error("source address not equal source-address-test")
+	}
+}
+func TestVpcCIDRBlock(t *testing.T) {
+	meta := NewMockMetaData(nil)
+	host, err := meta.VpcCIDRBlock()
+	if err != nil {
+		t.Errorf("vpcCIDRBlock err: %s", err.Error())
+	}
+	if host != "vpc-cidr-block-test" {
+		t.Error("vpc-cidr-block not equal vpc-cidr-block-test")
+	}
+}
+func TestVpcID(t *testing.T) {
+	meta := NewMockMetaData(nil)
+	host, err := meta.VpcID()
+	if err != nil {
+		t.Errorf("vpcID err: %s", err.Error())
+	}
+	if host != "vpc-id-test" {
+		t.Error("vpc-id not equal vpc-id-test")
+	}
+}
+func TestVswitchCIDRBlock(t *testing.T) {
+	meta := NewMockMetaData(nil)
+	host, err := meta.VswitchCIDRBlock()
+	if err != nil {
+		t.Errorf("vswitchCIDRBlock err: %s", err.Error())
+	}
+	if host != "vswitch-cidr-block-test" {
+		t.Error("vswitch-cidr-block not equal vswitch-cidr-block-test")
+	}
+}
+func TestVswitchID(t *testing.T) {
+	meta := NewMockMetaData(nil)
+	host, err := meta.VswitchID()
+	if err != nil {
+		t.Errorf("vswitch id err: %s", err.Error())
+	}
+	if host != "vswitch-id-test" {
+		t.Error("vswitch-id not equal vswitch-id-test")
+	}
+}
+func TestNTPConfigServers(t *testing.T) {
+	meta := NewMockMetaData(nil)
+	host, err := meta.NTPConfigServers()
+	if err != nil {
+		t.Errorf("ntpconfigservers err: %s", err.Error())
+	}
+	if host[0] != "ntp1.server.com" || host[1] != "ntp2.server.com" {
+		t.Error("ntp1.server.com not equal ntp1.server.com")
+	}
+}
+func TestDNSServers(t *testing.T) {
+	meta := NewMockMetaData(nil)
+	host, err := meta.DNSNameServers()
+	if err != nil {
+		t.Errorf("dnsservers err: %s", err.Error())
+	}
+	if host[0] != "8.8.8.8" || host[1] != "8.8.4.4" {
+		t.Error("dns servers not equal 8.8.8.8/8.8.4.4")
+	}
+}


### PR DESCRIPTION

## Add vpc instance metadata client support

Include metadata blow

```
	RS_TYPE_META_DATA = "meta-data"
	RS_TYPE_USER_DATA = "user-data"

	DNS_NAMESERVERS    = "dns-conf/nameservers"
	EIPV4              = "eipv4"
	HOSTNAME           = "hostname"
	IMAGE_ID           = "image-id"
	INSTANCE_ID        = "instance-id"
	MAC                = "mac"
	NETWORK_TYPE       = "network-type"
	NTP_CONF_SERVERS   = "ntp-conf/ntp-servers"
	OWNER_ACCOUNT_ID   = "owner-account-id"
	PRIVATE_IPV4       = "private-ipv4"
	REGION             = "region-id"
	SERIAL_NUMBER      = "serial-number"
	SOURCE_ADDRESS     = "source-address"
	VPC_CIDR_BLOCK     = "vpc-cidr-block"
	VPC_ID             = "vpc-id"
	VSWITCH_CIDR_BLOCK = "vswitch-cidr-block"
	VSWITCH_ID         = "vswitch-id"
```
**Note:** metadata client only available under aliyun vpc network

Signed-off-by: yaoyao.xyy <yaoyao.xyy@alibaba-inc.com>