### PR TITLE
internetchargetype in slb && gzip && healthchecktype && revivew bug

### DIFF
--- a/common/client.go
+++ b/common/client.go
@@ -74,12 +74,12 @@ func (client *Client) Invoke(action string, args interface{}, response interface
 
 	httpReq, err := http.NewRequest(ECSRequestMethod, requestURL, nil)
 
-	// TODO move to util and add build val flag
-	httpReq.Header.Set("X-SDK-Client", `AliyunGO/`+Version)
-
 	if err != nil {
 		return GetClientError(err)
 	}
+
+	// TODO move to util and add build val flag
+	httpReq.Header.Set("X-SDK-Client", `AliyunGO/`+Version)
 
 	t0 := time.Now()
 	httpResp, err := client.httpClient.Do(httpReq)

--- a/slb/listeners.go
+++ b/slb/listeners.go
@@ -2,6 +2,7 @@ package slb
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/denverdino/aliyungo/common"
@@ -49,6 +50,33 @@ const (
 	HTTP_5XX = HealthCheckHttpCodeType("http_5xx")
 )
 
+func EncodeHealthCheckHttpCodeType(healthCheckHttpCodes []HealthCheckHttpCodeType) (HealthCheckHttpCodeType, error) {
+	code := ""
+
+	if nil == healthCheckHttpCodes || len(healthCheckHttpCodes) < 1 {
+		return "", fmt.Errorf("Invalid size of healthCheckHttpCodes")
+	}
+
+	for _, healthCheckHttpCode := range healthCheckHttpCodes {
+		if strings.EqualFold(string(HTTP_2XX), string(healthCheckHttpCode)) ||
+			strings.EqualFold(string(HTTP_3XX), string(healthCheckHttpCode)) ||
+			strings.EqualFold(string(HTTP_4XX), string(healthCheckHttpCode)) ||
+			strings.EqualFold(string(HTTP_5XX), string(healthCheckHttpCode)) {
+			if "" == code {
+				code = string(healthCheckHttpCode)
+			} else {
+				if strings.Contains(code, string(healthCheckHttpCode)) {
+					return "", fmt.Errorf("Duplicates healthCheckHttpCode(%v in %v)", healthCheckHttpCode, healthCheckHttpCodes)
+				}
+				code += code + "," + string(healthCheckHttpCode)
+			}
+		} else {
+			return "", fmt.Errorf("Invalid healthCheckHttpCode(%v in %v)", healthCheckHttpCode, healthCheckHttpCodes)
+		}
+	}
+	return HealthCheckHttpCodeType(code), nil
+}
+
 type CommonLoadBalancerListenerResponse struct {
 	common.Response
 }
@@ -73,6 +101,7 @@ type HTTPListenerType struct {
 	HealthCheckInterval    int
 	HealthCheckHttpCode    HealthCheckHttpCodeType
 	VServerGroupId         string
+	Gzip                   FlagType
 }
 type CreateLoadBalancerHTTPListenerArgs HTTPListenerType
 

--- a/slb/loadbalancers.go
+++ b/slb/loadbalancers.go
@@ -12,12 +12,19 @@ const (
 	IntranetAddressType = AddressType("intranet")
 )
 
+type InternetChargeType string
+
+const (
+	PayByBandwidth = InternetChargeType("paybybandwidth")
+	PayByTraffic   = InternetChargeType("paybytraffic")
+)
+
 type CreateLoadBalancerArgs struct {
 	RegionId           common.Region
 	LoadBalancerName   string
 	AddressType        AddressType
 	VSwitchId          string
-	InternetChargeType common.InternetChargeType
+	InternetChargeType InternetChargeType
 	Bandwidth          int
 	ClientToken        string
 }
@@ -66,7 +73,7 @@ func (client *Client) DeleteLoadBalancer(loadBalancerId string) (err error) {
 
 type ModifyLoadBalancerInternetSpecArgs struct {
 	LoadBalancerId     string
-	InternetChargeType common.InternetChargeType
+	InternetChargeType InternetChargeType
 	Bandwidth          int
 }
 
@@ -144,7 +151,7 @@ type DescribeLoadBalancersArgs struct {
 	VpcId              string
 	VSwitchId          string
 	Address            string
-	InternetChargeType common.InternetChargeType
+	InternetChargeType InternetChargeType
 	ServerId           string
 }
 
@@ -170,7 +177,7 @@ type LoadBalancerType struct {
 	VpcId              string
 	NetworkType        string
 	Bandwidth          int
-	InternetChargeType common.InternetChargeType
+	InternetChargeType InternetChargeType
 	CreateTime         string //Why not ISO 6801
 	CreateTimeStamp    util.ISO6801Time
 	ListenerPorts      struct {


### PR DESCRIPTION
issue #87 ECS use internetchargetype is PayByBandwidth | PayByTraffic,
but SLB is paybybandwidth | paybytraffic , so I use a new type in SLB with the same name.
add gzip in create http or https or tcp(health check http)
add a func for encode mutiple healthcheckcode
fix a bug in client.Invoke(httpReq may be nil)