### PR TITLE
Add field LoadBalancerName to struct DescribeLoadBalancersArgs

### DIFF
--- a/slb/loadbalancers.go
+++ b/slb/loadbalancers.go
@@ -139,6 +139,7 @@ func (client *Client) SetLoadBalancerName(loadBalancerId string, name string) (e
 type DescribeLoadBalancersArgs struct {
 	RegionId           common.Region
 	LoadBalancerId     string
+	LoadBalancerName   string
 	AddressType        AddressType
 	NetworkType        string
 	VpcId              string


### PR DESCRIPTION

Add field LoadBalancerName to struct DescribeLoadBalancersArgs to enable search by LB name.

Signed-off-by: yaoyao.xyy <yaoyao.xyy@alibaba-inc.com>