### PR TITLE
fix incorrect field name FormAlias to FromAlias

### DIFF
--- a/dm/mail.go
+++ b/dm/mail.go
@@ -33,7 +33,7 @@ type SendSingleMailArgs struct {
 	SendEmailArgs
 	ReplyToAddress string
 	ToAddress      string
-	FormAlias      string
+	FromAlias      string
 	Subject        string
 	HtmlBody       string
 	TextBody       string
@@ -45,7 +45,7 @@ type SendSingleMailArgs struct {
 //1:sender's address
 //please set the receiverName and template in the console of Aliyun before you call this API,if you use tagName, you should set it as well
 
-//formAlias, subject, htmlBody, textBody are optional
+//fromAlias, subject, htmlBody, textBody are optional
 
 func (this *Client) SendSingleMail(args *SendSingleMailArgs) error {
 	return this.InvokeByAnyMethod(http.MethodPost, SingleSendMail, args, &common.Response{})


### PR DESCRIPTION
https://help.aliyun.com/document_detail/29444.html?spm=5176.doc29435.2.1.eHTlk0

使用的时候发现别名用不了，翻代码发现有个小命名错误 :)