### PR TITLE
add DescribeXXXWithRaw get raw response info

### DIFF
--- a/ecs/disks.go
+++ b/ecs/disks.go
@@ -110,15 +110,24 @@ type DescribeDisksResponse struct {
 //
 // You can read doc at http://docs.aliyun.com/#/pub/ecs/open-api/disk&describedisks
 func (client *Client) DescribeDisks(args *DescribeDisksArgs) (disks []DiskItemType, pagination *common.PaginationResult, err error) {
-	response := DescribeDisksResponse{}
-
-	err = client.Invoke("DescribeDisks", args, &response)
-
+	response, err := client.DescribeDisksWithRaw(args)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	return response.Disks.Disk, &response.PaginationResult, err
+}
+
+func (client *Client) DescribeDisksWithRaw(args *DescribeDisksArgs) (response *DescribeDisksResponse, err error) {
+	response = &DescribeDisksResponse{}
+
+	err = client.Invoke("DescribeDisks", args, response)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return response, err
 }
 
 type CreateDiskArgs struct {

--- a/ecs/forward_entry.go
+++ b/ecs/forward_entry.go
@@ -79,17 +79,25 @@ func (client *Client) CreateForwardEntry(args *CreateForwardEntryArgs) (resp *Cr
 
 func (client *Client) DescribeForwardTableEntries(args *DescribeForwardTableEntriesArgs) (forwardTableEntries []ForwardTableEntrySetType,
 	pagination *common.PaginationResult, err error) {
-
-	args.Validate()
-	response := DescribeForwardTableEntriesResponse{}
-
-	err = client.Invoke("DescribeForwardTableEntries", args, &response)
-
+	response, err := client.DescribeForwardTableEntriesWithRaw(args)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	return response.ForwardTableEntries.ForwardTableEntry, &response.PaginationResult, nil
+}
+
+func (client *Client) DescribeForwardTableEntriesWithRaw(args *DescribeForwardTableEntriesArgs) (response *DescribeForwardTableEntriesResponse, err error) {
+	args.Validate()
+	response = &DescribeForwardTableEntriesResponse{}
+
+	err = client.Invoke("DescribeForwardTableEntries", args, response)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
 }
 
 func (client *Client) ModifyForwardEntry(args *ModifyForwardEntryArgs) error {

--- a/ecs/images.go
+++ b/ecs/images.go
@@ -102,14 +102,21 @@ type ImageType struct {
 //
 // You can read doc at http://docs.aliyun.com/#/pub/ecs/open-api/image&describeimages
 func (client *Client) DescribeImages(args *DescribeImagesArgs) (images []ImageType, pagination *common.PaginationResult, err error) {
-
-	args.Validate()
-	response := DescribeImagesResponse{}
-	err = client.Invoke("DescribeImages", args, &response)
+	response, err := client.DescribeImagesWithRaw(args)
 	if err != nil {
 		return nil, nil, err
 	}
 	return response.Images.Image, &response.PaginationResult, nil
+}
+
+func (client *Client) DescribeImagesWithRaw(args *DescribeImagesArgs) (response *DescribeImagesResponse, err error) {
+	args.Validate()
+	response = &DescribeImagesResponse{}
+	err = client.Invoke("DescribeImages", args, response)
+	if err != nil {
+		return nil, err
+	}
+	return response, nil
 }
 
 // CreateImageArgs repsents arguments to create image

--- a/ecs/instances.go
+++ b/ecs/instances.go
@@ -94,16 +94,25 @@ type DescribeInstanceStatusResponse struct {
 //
 // You can read doc at http://docs.aliyun.com/#/pub/ecs/open-api/instance&describeinstancestatus
 func (client *Client) DescribeInstanceStatus(args *DescribeInstanceStatusArgs) (instanceStatuses []InstanceStatusItemType, pagination *common.PaginationResult, err error) {
-	args.Validate()
-	response := DescribeInstanceStatusResponse{}
-
-	err = client.Invoke("DescribeInstanceStatus", args, &response)
+	response, err := client.DescribeInstanceStatusWithRaw(args)
 
 	if err == nil {
 		return response.InstanceStatuses.InstanceStatus, &response.PaginationResult, nil
 	}
 
 	return nil, nil, err
+}
+
+func (client *Client) DescribeInstanceStatusWithRaw(args *DescribeInstanceStatusArgs) (response *DescribeInstanceStatusResponse, err error) {
+	args.Validate()
+	response = &DescribeInstanceStatusResponse{}
+
+	err = client.Invoke("DescribeInstanceStatus", args, response)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
 }
 
 type StopInstanceArgs struct {
@@ -408,16 +417,24 @@ type DescribeInstancesResponse struct {
 //
 // You can read doc at http://docs.aliyun.com/#/pub/ecs/open-api/instance&describeinstances
 func (client *Client) DescribeInstances(args *DescribeInstancesArgs) (instances []InstanceAttributesType, pagination *common.PaginationResult, err error) {
-	args.Validate()
-	response := DescribeInstancesResponse{}
-
-	err = client.Invoke("DescribeInstances", args, &response)
-
-	if err == nil {
-		return response.Instances.Instance, &response.PaginationResult, nil
+	response, err := client.DescribeInstancesWithRaw(args)
+	if err != nil {
+		return nil, nil, err
 	}
 
-	return nil, nil, err
+	return response.Instances.Instance, &response.PaginationResult, nil
+}
+
+func (client *Client) DescribeInstancesWithRaw(args *DescribeInstancesArgs) (response *DescribeInstancesResponse, err error) {
+	args.Validate()
+	response = &DescribeInstancesResponse{}
+
+	err = client.Invoke("DescribeInstances", args, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
 }
 
 type DeleteInstanceArgs struct {

--- a/ecs/nat_gateway.go
+++ b/ecs/nat_gateway.go
@@ -83,17 +83,25 @@ type DescribeNatGatewaysArgs struct {
 
 func (client *Client) DescribeNatGateways(args *DescribeNatGatewaysArgs) (natGateways []NatGatewaySetType,
 	pagination *common.PaginationResult, err error) {
-
-	args.Validate()
-	response := DescribeNatGatewayResponse{}
-
-	err = client.Invoke("DescribeNatGateways", args, &response)
-
+	response, err := client.DescribeNatGatewaysWithRaw(args)
 	if err == nil {
 		return response.NatGateways.NatGateway, &response.PaginationResult, nil
 	}
 
 	return nil, nil, err
+}
+
+func (client *Client) DescribeNatGatewaysWithRaw(args *DescribeNatGatewaysArgs) (response *DescribeNatGatewayResponse, err error) {
+	args.Validate()
+	response = &DescribeNatGatewayResponse{}
+
+	err = client.Invoke("DescribeNatGateways", args, response)
+
+	if err == nil {
+		return response, nil
+	}
+
+	return nil, err
 }
 
 type ModifyNatGatewayAttributeArgs struct {

--- a/ecs/networks.go
+++ b/ecs/networks.go
@@ -146,16 +146,25 @@ type DescribeEipAddressesResponse struct {
 //
 // You can read doc at http://docs.aliyun.com/#/pub/ecs/open-api/network&describeeipaddresses
 func (client *Client) DescribeEipAddresses(args *DescribeEipAddressesArgs) (eipAddresses []EipAddressSetType, pagination *common.PaginationResult, err error) {
-	args.Validate()
-	response := DescribeEipAddressesResponse{}
-
-	err = client.Invoke("DescribeEipAddresses", args, &response)
-
+	response, err := client.DescribeEipAddressesWithRaw(args)
 	if err == nil {
 		return response.EipAddresses.EipAddress, &response.PaginationResult, nil
 	}
 
 	return nil, nil, err
+}
+
+func (client *Client) DescribeEipAddressesWithRaw(args *DescribeEipAddressesArgs) (response *DescribeEipAddressesResponse, err error) {
+	args.Validate()
+	response = &DescribeEipAddressesResponse{}
+
+	err = client.Invoke("DescribeEipAddresses", args, response)
+
+	if err == nil {
+		return response, nil
+	}
+
+	return nil, err
 }
 
 type ModifyEipAddressAttributeArgs struct {

--- a/ecs/route_tables.go
+++ b/ecs/route_tables.go
@@ -76,16 +76,25 @@ type DescribeRouteTablesResponse struct {
 //
 // You can read doc at http://docs.aliyun.com/#/pub/ecs/open-api/routertable&describeroutetables
 func (client *Client) DescribeRouteTables(args *DescribeRouteTablesArgs) (routeTables []RouteTableSetType, pagination *common.PaginationResult, err error) {
-	args.Validate()
-	response := DescribeRouteTablesResponse{}
-
-	err = client.Invoke("DescribeRouteTables", args, &response)
-
+	response, err := client.DescribeRouteTablesWithRaw(args)
 	if err == nil {
 		return response.RouteTables.RouteTable, &response.PaginationResult, nil
 	}
 
 	return nil, nil, err
+}
+
+func (client *Client) DescribeRouteTablesWithRaw(args *DescribeRouteTablesArgs) (response *DescribeRouteTablesResponse, err error) {
+	args.Validate()
+	response = &DescribeRouteTablesResponse{}
+
+	err = client.Invoke("DescribeRouteTables", args, &response)
+
+	if err == nil {
+		return response, nil
+	}
+
+	return nil, err
 }
 
 type NextHopType string

--- a/ecs/security_groups.go
+++ b/ecs/security_groups.go
@@ -108,16 +108,25 @@ type DescribeSecurityGroupsResponse struct {
 //
 // You can read doc at http://docs.aliyun.com/#/pub/ecs/open-api/securitygroup&describesecuritygroups
 func (client *Client) DescribeSecurityGroups(args *DescribeSecurityGroupsArgs) (securityGroupItems []SecurityGroupItemType, pagination *common.PaginationResult, err error) {
-	args.Validate()
-	response := DescribeSecurityGroupsResponse{}
-
-	err = client.Invoke("DescribeSecurityGroups", args, &response)
-
+	response, err := client.DescribeSecurityGroupsWithRaw(args)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	return response.SecurityGroups.SecurityGroup, &response.PaginationResult, nil
+}
+
+func (client *Client) DescribeSecurityGroupsWithRaw(args *DescribeSecurityGroupsArgs) (response *DescribeSecurityGroupsResponse, err error) {
+	args.Validate()
+	response = &DescribeSecurityGroupsResponse{}
+
+	err = client.Invoke("DescribeSecurityGroups", args, response)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
 }
 
 type CreateSecurityGroupArgs struct {

--- a/ecs/snapshots.go
+++ b/ecs/snapshots.go
@@ -41,15 +41,24 @@ type DescribeSnapshotsResponse struct {
 //
 // You can read doc at http://docs.aliyun.com/#/pub/ecs/open-api/snapshot&describesnapshots
 func (client *Client) DescribeSnapshots(args *DescribeSnapshotsArgs) (snapshots []SnapshotType, pagination *common.PaginationResult, err error) {
-	args.Validate()
-	response := DescribeSnapshotsResponse{}
-
-	err = client.Invoke("DescribeSnapshots", args, &response)
-
+	response, err := client.DescribeSnapshotsWithRaw(args)
 	if err != nil {
 		return nil, nil, err
 	}
 	return response.Snapshots.Snapshot, &response.PaginationResult, nil
+
+}
+
+func (client *Client) DescribeSnapshotsWithRaw(args *DescribeSnapshotsArgs) (response *DescribeSnapshotsResponse, err error) {
+	args.Validate()
+	response = &DescribeSnapshotsResponse{}
+
+	err = client.Invoke("DescribeSnapshots", args, response)
+
+	if err != nil {
+		return nil, err
+	}
+	return response, nil
 
 }
 

--- a/ecs/snat_entry.go
+++ b/ecs/snat_entry.go
@@ -70,17 +70,25 @@ func (client *Client) CreateSnatEntry(args *CreateSnatEntryArgs) (resp *CreateSn
 
 func (client *Client) DescribeSnatTableEntries(args *DescribeSnatTableEntriesArgs) (snatTableEntries []SnatEntrySetType,
 	pagination *common.PaginationResult, err error) {
-
-	args.Validate()
-	response := DescribeSnatTableEntriesResponse{}
-
-	err = client.Invoke("DescribeSnatTableEntries", args, &response)
-
+	response, err := client.DescribeSnatTableEntriesWithRaw(args)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	return response.SnatTableEntries.SnatTableEntry, &response.PaginationResult, nil
+}
+
+func (client *Client) DescribeSnatTableEntriesWithRaw(args *DescribeSnatTableEntriesArgs) ( response *DescribeSnatTableEntriesResponse, err error) {
+	args.Validate()
+	response = &DescribeSnatTableEntriesResponse{}
+
+	err = client.Invoke("DescribeSnatTableEntries", args, response)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
 }
 
 func (client *Client) ModifySnatEntry(args *ModifySnatEntryArgs) error {

--- a/ecs/ssh_key_pair.go
+++ b/ecs/ssh_key_pair.go
@@ -77,15 +77,24 @@ type DescribeKeyPairsResponse struct {
 //
 // You can read doc at https://help.aliyun.com/document_detail/51773.html?spm=5176.doc51774.6.912.lyE0iX
 func (client *Client) DescribeKeyPairs(args *DescribeKeyPairsArgs) (KeyPairs   []KeyPairItemType, pagination *common.PaginationResult, err error) {
-	response := DescribeKeyPairsResponse{}
-
-	err = client.Invoke("DescribeKeyPairs", args, &response)
-
+	response, err := client.DescribeKeyPairsWithRaw(args)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	return response.KeyPairs.KeyPair, &response.PaginationResult, err
+}
+
+func (client *Client) DescribeKeyPairsWithRaw(args *DescribeKeyPairsArgs) (response *DescribeKeyPairsResponse, err error) {
+	response = &DescribeKeyPairsResponse{}
+
+	err = client.Invoke("DescribeKeyPairs", args, response)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return response, err
 }
 
 type AttachKeyPairArgs struct {

--- a/ecs/tags.go
+++ b/ecs/tags.go
@@ -76,13 +76,21 @@ type DescribeResourceByTagsResponse struct {
 //
 // You can read doc at http://docs.aliyun.com/#/pub/ecs/open-api/tags&describeresourcebytags
 func (client *Client) DescribeResourceByTags(args *DescribeResourceByTagsArgs) (resources []ResourceItemType, pagination *common.PaginationResult, err error) {
-	args.Validate()
-	response := DescribeResourceByTagsResponse{}
-	err = client.Invoke("DescribeResourceByTags", args, &response)
+	response, err := client.DescribeResourceByTagsWithRaw(args)
 	if err != nil {
 		return nil, nil, err
 	}
 	return response.Resources.Resource, &response.PaginationResult, nil
+}
+
+func (client *Client) DescribeResourceByTagsWithRaw(args *DescribeResourceByTagsArgs) (response *DescribeResourceByTagsResponse, err error) {
+	args.Validate()
+	response = &DescribeResourceByTagsResponse{}
+	err = client.Invoke("DescribeResourceByTags", args, response)
+	if err != nil {
+		return nil, err
+	}
+	return response, nil
 }
 
 type TagItemType struct {

--- a/ecs/vpcs.go
+++ b/ecs/vpcs.go
@@ -95,16 +95,24 @@ type DescribeVpcsResponse struct {
 //
 // You can read doc at http://docs.aliyun.com/#/pub/ecs/open-api/vpc&describevpcs
 func (client *Client) DescribeVpcs(args *DescribeVpcsArgs) (vpcs []VpcSetType, pagination *common.PaginationResult, err error) {
-	args.Validate()
-	response := DescribeVpcsResponse{}
-
-	err = client.Invoke("DescribeVpcs", args, &response)
-
-	if err == nil {
-		return response.Vpcs.Vpc, &response.PaginationResult, nil
+	response, err := client.DescribeVpcsWithRaw(args)
+	if err != nil {
+		return nil, nil, err
 	}
 
-	return nil, nil, err
+	return response.Vpcs.Vpc, &response.PaginationResult, nil
+}
+
+func (client *Client) DescribeVpcsWithRaw(args *DescribeVpcsArgs) (response *DescribeVpcsResponse, err error) {
+	args.Validate()
+	response = &DescribeVpcsResponse{}
+
+	err = client.Invoke("DescribeVpcs", args, response)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, err
 }
 
 type ModifyVpcAttributeArgs struct {

--- a/ecs/vrouters.go
+++ b/ecs/vrouters.go
@@ -37,16 +37,25 @@ type DescribeVRoutersResponse struct {
 //
 // You can read doc at http://docs.aliyun.com/#/pub/ecs/open-api/vrouter&describevrouters
 func (client *Client) DescribeVRouters(args *DescribeVRoutersArgs) (vrouters []VRouterSetType, pagination *common.PaginationResult, err error) {
-	args.Validate()
-	response := DescribeVRoutersResponse{}
-
-	err = client.Invoke("DescribeVRouters", args, &response)
-
+	response, err := client.DescribeVRoutersWithRaw(args)
 	if err == nil {
 		return response.VRouters.VRouter, &response.PaginationResult, nil
 	}
 
 	return nil, nil, err
+}
+
+func (client *Client) DescribeVRoutersWithRaw(args *DescribeVRoutersArgs) (response *DescribeVRoutersResponse, err error) {
+	args.Validate()
+	response = &DescribeVRoutersResponse{}
+
+	err = client.Invoke("DescribeVRouters", args, response)
+
+	if err == nil {
+		return response, nil
+	}
+
+	return nil, err
 }
 
 type ModifyVRouterAttributeArgs struct {

--- a/ecs/vswitches.go
+++ b/ecs/vswitches.go
@@ -94,15 +94,25 @@ type DescribeVSwitchesResponse struct {
 // You can read doc at http://docs.aliyun.com/#/pub/ecs/open-api/vswitch&describevswitches
 func (client *Client) DescribeVSwitches(args *DescribeVSwitchesArgs) (vswitches []VSwitchSetType, pagination *common.PaginationResult, err error) {
 	args.Validate()
-	response := DescribeVSwitchesResponse{}
-
-	err = client.Invoke("DescribeVSwitches", args, &response)
-
+	response, err := client.DescribeVSwitchesWithRaw(args)
 	if err == nil {
 		return response.VSwitches.VSwitch, &response.PaginationResult, nil
 	}
 
 	return nil, nil, err
+}
+
+func (client *Client) DescribeVSwitchesWithRaw(args *DescribeVSwitchesArgs) (response *DescribeVSwitchesResponse, err error) {
+	args.Validate()
+	response = &DescribeVSwitchesResponse{}
+
+	err = client.Invoke("DescribeVSwitches", args, &response)
+
+	if err == nil {
+		return response, nil
+	}
+
+	return nil, err
 }
 
 type ModifyVSwitchAttributeArgs struct {

--- a/ecs/zones.go
+++ b/ecs/zones.go
@@ -50,16 +50,25 @@ type DescribeZonesResponse struct {
 
 // DescribeZones describes zones
 func (client *Client) DescribeZones(regionId common.Region) (zones []ZoneType, err error) {
-	args := DescribeZonesArgs{
-		RegionId: regionId,
-	}
-	response := DescribeZonesResponse{}
-
-	err = client.Invoke("DescribeZones", &args, &response)
-
+	response, err := client.DescribeZonesWithRaw(regionId)
 	if err == nil {
 		return response.Zones.Zone, nil
 	}
 
 	return []ZoneType{}, err
+}
+
+func (client *Client) DescribeZonesWithRaw(regionId common.Region) (response *DescribeZonesResponse, err error) {
+	args := DescribeZonesArgs{
+		RegionId: regionId,
+	}
+	response = &DescribeZonesResponse{}
+
+	err = client.Invoke("DescribeZones", &args, response)
+
+	if err == nil {
+		return response, nil
+	}
+
+	return nil, err
 }


### PR DESCRIPTION
ECS 的 Describe API 中所有带分页功能的接口原来的返回的都不是原生的 response 信息，返回信息中把 common.Response （requestId）信息都丢失了。所以对 ECS 的 Describe API 添加了 DescribexxxWithRaw 函数返回原生的 Response 信息