### PR TITLE
第一、ReadOnlyDBInstanceId 的类型应该是数组（RDS 有只读实例时），第二、DescribeDBInstancePerformanceArgs的 key 首字母应该大写

### DIFF
--- a/rds/instances.go
+++ b/rds/instances.go
@@ -192,8 +192,13 @@ type DBInstanceAttribute struct {
 	VpcId                       string
 }
 
+
 type ReadOnlyDBInstanceIds struct {
-	ReadOnlyDBInstanceId []string
+	ReadOnlyDBInstanceId []ReadOnlyDBInstanceId
+}
+
+type ReadOnlyDBInstanceId struct {
+	DBInstanceId string
 }
 
 // DescribeDBInstanceAttribute describes db instance

--- a/rds/monitoring.go
+++ b/rds/monitoring.go
@@ -7,7 +7,7 @@ import (
 
 type DescribeDBInstancePerformanceArgs struct {
 	DBInstanceId string
-	key          string
+	Key          string
 	StartTime    string
 	EndTime      string
 }
@@ -38,7 +38,7 @@ type DescribeDBInstancePerformanceResponse struct {
 }
 
 func (client *DescribeDBInstancePerformanceArgs) Setkey(key string) {
-	client.key = key
+	client.Key = key
 }
 
 func (client *Client) DescribeDBInstancePerformance(args *DescribeDBInstancePerformanceArgs) (resp DescribeDBInstancePerformanceResponse, err error) {


### PR DESCRIPTION
主数据库可以有多个只读库，所以 ReadOnlyDBInstanceId 应该要修改，例如有一个只读库时：
"ReadOnlyDBInstanceIds":{"ReadOnlyDBInstanceId":[{"DBInstanceId":"rr-bpxxxxxxx"}]}