### PR TITLE
modify cdn source type OSS to oss

### DIFF
--- a/cdn/types.go
+++ b/cdn/types.go
@@ -12,7 +12,7 @@ const (
 	LiveStream                = "liveStream"
 	Ipaddr                    = "ipaddr"
 	Domain                    = "domain"
-	OSS                       = "OSS"
+	OSS                       = "oss"
 	Domestic                  = "domestic"
 	Overseas                  = "overseas"
 	Global                    = "global"


### PR DESCRIPTION
CDN API valid source type should be "ipaddr", "domain" and  "oss".