### PR TITLE
Support to create Clients from credentials of assumed role

### DIFF
--- a/common/client.go
+++ b/common/client.go
@@ -3,6 +3,8 @@ package common
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -25,6 +27,7 @@ type UnderlineString string
 type Client struct {
 	AccessKeyId     string //Access Key Id
 	AccessKeySecret string //Access Key Secret
+	securityToken   string
 	debug           bool
 	httpClient      *http.Client
 	endpoint        string
@@ -32,10 +35,10 @@ type Client struct {
 	serviceCode     string
 	regionID        Region
 	businessInfo    string
-	userAgent 	string
+	userAgent       string
 }
 
-// NewClient creates a new instance of ECS client
+// Initialize properties of a client instance
 func (client *Client) Init(endpoint, version, accessKeyId, accessKeySecret string) {
 	client.AccessKeyId = accessKeyId
 	client.AccessKeySecret = accessKeySecret + "&"
@@ -45,11 +48,20 @@ func (client *Client) Init(endpoint, version, accessKeyId, accessKeySecret strin
 	client.version = version
 }
 
+// Initialize properties of a client instance including regionID
 func (client *Client) NewInit(endpoint, version, accessKeyId, accessKeySecret, serviceCode string, regionID Region) {
 	client.Init(endpoint, version, accessKeyId, accessKeySecret)
 	client.serviceCode = serviceCode
 	client.regionID = regionID
 	client.setEndpointByLocation(regionID, serviceCode, accessKeyId, accessKeySecret)
+}
+
+// Intialize client object when all properties are ready
+func (client *Client) InitClient() *Client {
+	client.debug = false
+	client.httpClient = &http.Client{}
+	client.setEndpointByLocation(client.regionID, client.serviceCode, client.AccessKeyId, client.AccessKeySecret)
+	return client
 }
 
 //NewClient using location service
@@ -65,6 +77,95 @@ func (client *Client) setEndpointByLocation(region Region, serviceCode, accessKe
 	}
 }
 
+// Ensure all necessary properties are valid
+func (client *Client) ensureProperties() error {
+	var msg string
+
+	if client.endpoint == "" {
+		msg = fmt.Sprintf("endpoint cannot be empty!")
+	} else if client.version == "" {
+		msg = fmt.Sprintf("version cannot be empty!")
+	} else if client.AccessKeyId == "" {
+		msg = fmt.Sprintf("AccessKeyId cannot be empty!")
+	} else if client.AccessKeySecret == "" {
+		msg = fmt.Sprintf("AccessKeySecret cannot be empty!")
+	}
+
+	if msg != "" {
+		return errors.New(msg)
+	}
+
+	return nil
+}
+
+// ----------------------------------------------------
+// WithXXX methods
+// ----------------------------------------------------
+
+// WithEndpoint sets custom endpoint
+func (client *Client) WithEndpoint(endpoint string) *Client {
+	client.SetEndpoint(endpoint)
+	return client
+}
+
+// WithVersion sets custom version
+func (client *Client) WithVersion(version string) *Client {
+	client.SetVersion(version)
+	return client
+}
+
+// WithRegionID sets Region ID
+func (client *Client) WithRegionID(regionID Region) *Client {
+	client.SetRegionID(regionID)
+	return client
+}
+
+//WithServiceCode sets serviceCode
+func (client *Client) WithServiceCode(serviceCode string) *Client {
+	client.SetServiceCode(serviceCode)
+	return client
+}
+
+// WithAccessKeyId sets new AccessKeyId
+func (client *Client) WithAccessKeyId(id string) *Client {
+	client.SetAccessKeyId(id)
+	return client
+}
+
+// WithAccessKeySecret sets new AccessKeySecret
+func (client *Client) WithAccessKeySecret(secret string) *Client {
+	client.SetAccessKeySecret(secret)
+	return client
+}
+
+// WithSecurityToken sets securityToken
+func (client *Client) WithSecurityToken(securityToken string) *Client {
+	client.SetSecurityToken(securityToken)
+	return client
+}
+
+// WithDebug sets debug mode to log the request/response message
+func (client *Client) WithDebug(debug bool) *Client {
+	client.SetDebug(debug)
+	return client
+}
+
+// WithBusinessInfo sets business info to log the request/response message
+func (client *Client) WithBusinessInfo(businessInfo string) *Client {
+	client.SetBusinessInfo(businessInfo)
+	return client
+}
+
+// WithUserAgent sets user agent to the request/response message
+func (client *Client) WithUserAgent(userAgent string) *Client {
+	client.SetUserAgent(userAgent)
+	return client
+}
+
+// ----------------------------------------------------
+// SetXXX methods
+// ----------------------------------------------------
+
 // SetEndpoint sets custom endpoint
 func (client *Client) SetEndpoint(endpoint string) {
 	client.endpoint = endpoint
@@ -75,6 +176,7 @@ func (client *Client) SetVersion(version string) {
 	client.version = version
 }
 
+// SetEndpoint sets Region ID
 func (client *Client) SetRegionID(regionID Region) {
 	client.regionID = regionID
 }
@@ -92,6 +194,11 @@ func (client *Client) SetAccessKeyId(id string) {
 // SetAccessKeySecret sets new AccessKeySecret
 func (client *Client) SetAccessKeySecret(secret string) {
 	client.AccessKeySecret = secret + "&"
+}
+
+// SetAccessKeySecret sets securityToken
+func (client *Client) SetSecurityToken(securityToken string) {
+	client.securityToken = securityToken
 }
 
 // SetDebug sets debug mode to log the request/response message
@@ -115,9 +222,12 @@ func (client *Client) SetUserAgent(userAgent string) {
 
 // Invoke sends the raw HTTP request for ECS services
 func (client *Client) Invoke(action string, args interface{}, response interface{}) error {
+	if err := client.ensureProperties(); err != nil {
+		return err
+	}
 
 	request := Request{}
-	request.init(client.version, action, client.AccessKeyId)
+	request.init(client.version, action, client.AccessKeyId, client.securityToken)
 
 	query := util.ConvertToQueryValues(request)
 	util.SetQueryValues(args, &query)
@@ -136,8 +246,7 @@ func (client *Client) Invoke(action string, args interface{}, response interface
 
 	// TODO move to util and add build val flag
 	httpReq.Header.Set("X-SDK-Client", `AliyunGO/`+Version+client.businessInfo)
-
-	httpReq.Header.Set("User-Agent", httpReq.UserAgent()+ " " +client.userAgent)
+	httpReq.Header.Set("User-Agent", httpReq.UserAgent()+" "+client.userAgent)
 
 	t0 := time.Now()
 	httpResp, err := client.httpClient.Do(httpReq)
@@ -185,9 +294,12 @@ func (client *Client) Invoke(action string, args interface{}, response interface
 
 // Invoke sends the raw HTTP request for ECS services
 func (client *Client) InvokeByFlattenMethod(action string, args interface{}, response interface{}) error {
+	if err := client.ensureProperties(); err != nil {
+		return err
+	}
 
 	request := Request{}
-	request.init(client.version, action, client.AccessKeyId)
+	request.init(client.version, action, client.AccessKeyId, client.securityToken)
 
 	query := util.ConvertToQueryValues(request)
 
@@ -207,8 +319,7 @@ func (client *Client) InvokeByFlattenMethod(action string, args interface{}, res
 
 	// TODO move to util and add build val flag
 	httpReq.Header.Set("X-SDK-Client", `AliyunGO/`+Version+client.businessInfo)
-
-	httpReq.Header.Set("User-Agent", httpReq.UserAgent()+ " " +client.userAgent)
+	httpReq.Header.Set("User-Agent", httpReq.UserAgent()+" "+client.userAgent)
 
 	t0 := time.Now()
 	httpResp, err := client.httpClient.Do(httpReq)
@@ -258,9 +369,12 @@ func (client *Client) InvokeByFlattenMethod(action string, args interface{}, res
 //改进了一下上面那个方法，可以使用各种Http方法
 //2017.1.30 增加了一个path参数，用来拓展访问的地址
 func (client *Client) InvokeByAnyMethod(method, action, path string, args interface{}, response interface{}) error {
+	if err := client.ensureProperties(); err != nil {
+		return err
+	}
 
 	request := Request{}
-	request.init(client.version, action, client.AccessKeyId)
+	request.init(client.version, action, client.AccessKeyId, client.securityToken)
 
 	data := util.ConvertToQueryValues(request)
 	util.SetQueryValues(args, &data)
@@ -290,8 +404,7 @@ func (client *Client) InvokeByAnyMethod(method, action, path string, args interf
 
 	// TODO move to util and add build val flag
 	httpReq.Header.Set("X-SDK-Client", `AliyunGO/`+Version+client.businessInfo)
-
-	httpReq.Header.Set("User-Agent", httpReq.Header.Get("User-Agent")+ " " +client.userAgent)
+	httpReq.Header.Set("User-Agent", httpReq.Header.Get("User-Agent")+" "+client.userAgent)
 
 	t0 := time.Now()
 	httpResp, err := client.httpClient.Do(httpReq)

--- a/common/client.go
+++ b/common/client.go
@@ -227,7 +227,7 @@ func (client *Client) Invoke(action string, args interface{}, response interface
 	}
 
 	request := Request{}
-	request.init(client.version, action, client.AccessKeyId, client.securityToken)
+	request.init(client.version, action, client.AccessKeyId, client.securityToken, client.regionID)
 
 	query := util.ConvertToQueryValues(request)
 	util.SetQueryValues(args, &query)
@@ -299,7 +299,7 @@ func (client *Client) InvokeByFlattenMethod(action string, args interface{}, res
 	}
 
 	request := Request{}
-	request.init(client.version, action, client.AccessKeyId, client.securityToken)
+	request.init(client.version, action, client.AccessKeyId, client.securityToken, client.regionID)
 
 	query := util.ConvertToQueryValues(request)
 
@@ -374,7 +374,7 @@ func (client *Client) InvokeByAnyMethod(method, action, path string, args interf
 	}
 
 	request := Request{}
-	request.init(client.version, action, client.AccessKeyId, client.securityToken)
+	request.init(client.version, action, client.AccessKeyId, client.securityToken, client.regionID)
 
 	data := util.ConvertToQueryValues(request)
 	util.SetQueryValues(args, &data)

--- a/common/request.go
+++ b/common/request.go
@@ -20,6 +20,7 @@ const (
 type Request struct {
 	Format               string
 	Version              string
+	RegionId             Region
 	AccessKeyId          string
 	SecurityToken        string
 	Signature            string
@@ -31,7 +32,7 @@ type Request struct {
 	Action               string
 }
 
-func (request *Request) init(version string, action string, AccessKeyId string, securityToken string) {
+func (request *Request) init(version string, action string, AccessKeyId string, securityToken string, regionId Region) {
 	request.Format = JSONResponseFormat
 	request.Timestamp = util.NewISO6801Time(time.Now().UTC())
 	request.Version = version
@@ -41,6 +42,7 @@ func (request *Request) init(version string, action string, AccessKeyId string, 
 	request.Action = action
 	request.AccessKeyId = AccessKeyId
 	request.SecurityToken = securityToken
+	request.RegionId = regionId
 }
 
 type Response struct {

--- a/common/request.go
+++ b/common/request.go
@@ -21,6 +21,7 @@ type Request struct {
 	Format               string
 	Version              string
 	AccessKeyId          string
+	SecurityToken        string
 	Signature            string
 	SignatureMethod      string
 	Timestamp            util.ISO6801Time
@@ -30,7 +31,7 @@ type Request struct {
 	Action               string
 }
 
-func (request *Request) init(version string, action string, AccessKeyId string) {
+func (request *Request) init(version string, action string, AccessKeyId string, securityToken string) {
 	request.Format = JSONResponseFormat
 	request.Timestamp = util.NewISO6801Time(time.Now().UTC())
 	request.Version = version
@@ -39,6 +40,7 @@ func (request *Request) init(version string, action string, AccessKeyId string) 
 	request.SignatureNonce = util.CreateRandomString()
 	request.Action = action
 	request.AccessKeyId = AccessKeyId
+	request.SecurityToken = securityToken
 }
 
 type Response struct {

--- a/ecs/client.go
+++ b/ecs/client.go
@@ -71,7 +71,6 @@ func NewECSClientWithEndpoint(endpoint string, accessKeyId string, accessKeySecr
 func NewECSClientWithEndpointAndSecurityToken(endpoint string, accessKeyId string, accessKeySecret string, securityToken string, regionID common.Region) *Client {
 	client := &Client{}
 	client.WithEndpoint(endpoint).
-		WithEndpoint(endpoint).
 		WithVersion(ECSAPIVersion).
 		WithAccessKeyId(accessKeyId).
 		WithAccessKeySecret(accessKeySecret).
@@ -105,7 +104,6 @@ func NewVPCClientWithEndpoint(endpoint string, accessKeyId string, accessKeySecr
 func NewVPCClientWithEndpointAndSecurityToken(endpoint string, accessKeyId string, accessKeySecret string, securityToken string, regionID common.Region) *Client {
 	client := &Client{}
 	client.WithEndpoint(endpoint).
-		WithEndpoint(endpoint).
 		WithVersion(VPCAPIVersion).
 		WithAccessKeyId(accessKeyId).
 		WithAccessKeySecret(accessKeySecret).

--- a/ecs/client.go
+++ b/ecs/client.go
@@ -20,8 +20,7 @@ const (
 	// ECSDefaultEndpoint is the default API endpoint of ECS services
 	ECSDefaultEndpoint = "https://ecs-cn-hangzhou.aliyuncs.com"
 	ECSAPIVersion      = "2014-05-26"
-
-	ECSServiceCode = "ecs"
+	ECSServiceCode     = "ecs"
 
 	VPCDefaultEndpoint = "https://vpc.aliyuncs.com"
 	VPCAPIVersion      = "2016-04-28"
@@ -37,38 +36,82 @@ func NewClient(accessKeyId, accessKeySecret string) *Client {
 	return NewClientWithEndpoint(endpoint, accessKeyId, accessKeySecret)
 }
 
-func NewECSClient(accessKeyId, accessKeySecret string, regionID common.Region) *Client {
-	endpoint := os.Getenv("ECS_ENDPOINT")
-	if endpoint == "" {
-		endpoint = ECSDefaultEndpoint
-	}
-
-	return NewClientWithRegion(endpoint, accessKeyId, accessKeySecret, regionID)
-}
-
-func NewClientWithRegion(endpoint string, accessKeyId, accessKeySecret string, regionID common.Region) *Client {
+func NewClientWithRegion(endpoint string, accessKeyId string, accessKeySecret string, regionID common.Region) *Client {
 	client := &Client{}
 	client.NewInit(endpoint, ECSAPIVersion, accessKeyId, accessKeySecret, ECSServiceCode, regionID)
 	return client
 }
 
-func NewClientWithEndpoint(endpoint string, accessKeyId, accessKeySecret string) *Client {
+func NewClientWithEndpoint(endpoint string, accessKeyId string, accessKeySecret string) *Client {
 	client := &Client{}
 	client.Init(endpoint, ECSAPIVersion, accessKeyId, accessKeySecret)
 	return client
 }
 
-func NewVPCClient(accessKeyId, accessKeySecret string, regionID common.Region) *Client {
+// ---------------------------------------
+// NewECSClient creates a new instance of ECS client
+// ---------------------------------------
+func NewECSClient(accessKeyId, accessKeySecret string, regionID common.Region) *Client {
+	return NewECSClientWithSecurityToken(accessKeyId, accessKeySecret, "", regionID)
+}
+
+func NewECSClientWithSecurityToken(accessKeyId string, accessKeySecret string, securityToken string, regionID common.Region) *Client {
+	endpoint := os.Getenv("ECS_ENDPOINT")
+	if endpoint == "" {
+		endpoint = ECSDefaultEndpoint
+	}
+
+	return NewECSClientWithEndpointAndSecurityToken(endpoint, accessKeyId, accessKeySecret, securityToken, regionID)
+}
+
+func NewECSClientWithEndpoint(endpoint string, accessKeyId string, accessKeySecret string, regionID common.Region) *Client {
+	return NewECSClientWithEndpointAndSecurityToken(endpoint, accessKeyId, accessKeySecret, "", regionID)
+}
+
+func NewECSClientWithEndpointAndSecurityToken(endpoint string, accessKeyId string, accessKeySecret string, securityToken string, regionID common.Region) *Client {
+	client := &Client{}
+	client.WithEndpoint(endpoint).
+		WithEndpoint(endpoint).
+		WithVersion(ECSAPIVersion).
+		WithAccessKeyId(accessKeyId).
+		WithAccessKeySecret(accessKeySecret).
+		WithSecurityToken(securityToken).
+		WithServiceCode(ECSServiceCode).
+		WithRegionID(regionID).
+		InitClient()
+	return client
+}
+
+// ---------------------------------------
+// NewVPCClient creates a new instance of VPC client
+// ---------------------------------------
+func NewVPCClient(accessKeyId string, accessKeySecret string, regionID common.Region) *Client {
+	return NewVPCClientWithSecurityToken(accessKeyId, accessKeySecret, "", regionID)
+}
+
+func NewVPCClientWithSecurityToken(accessKeyId string, accessKeySecret string, securityToken string, regionID common.Region) *Client {
 	endpoint := os.Getenv("VPC_ENDPOINT")
 	if endpoint == "" {
 		endpoint = VPCDefaultEndpoint
 	}
 
-	return NewVPCClientWithRegion(endpoint, accessKeyId, accessKeySecret, regionID)
+	return NewVPCClientWithEndpointAndSecurityToken(endpoint, accessKeyId, accessKeySecret, securityToken, regionID)
 }
 
-func NewVPCClientWithRegion(endpoint string, accessKeyId, accessKeySecret string, regionID common.Region) *Client {
+func NewVPCClientWithEndpoint(endpoint string, accessKeyId string, accessKeySecret string, regionID common.Region) *Client {
+	return NewVPCClientWithEndpointAndSecurityToken(endpoint, accessKeyId, accessKeySecret, "", regionID)
+}
+
+func NewVPCClientWithEndpointAndSecurityToken(endpoint string, accessKeyId string, accessKeySecret string, securityToken string, regionID common.Region) *Client {
 	client := &Client{}
-	client.NewInit(endpoint, VPCAPIVersion, accessKeyId, accessKeySecret, VPCServiceCode, regionID)
+	client.WithEndpoint(endpoint).
+		WithEndpoint(endpoint).
+		WithVersion(VPCAPIVersion).
+		WithAccessKeyId(accessKeyId).
+		WithAccessKeySecret(accessKeySecret).
+		WithSecurityToken(securityToken).
+		WithServiceCode(VPCServiceCode).
+		WithRegionID(regionID).
+		InitClient()
 	return client
 }

--- a/ram/client.go
+++ b/ram/client.go
@@ -1,8 +1,9 @@
 package ram
 
 import (
-	"github.com/denverdino/aliyungo/common"
 	"os"
+
+	"github.com/denverdino/aliyungo/common"
 )
 
 const (
@@ -16,15 +17,30 @@ type RamClient struct {
 }
 
 func NewClient(accessKeyId string, accessKeySecret string) RamClientInterface {
+	return NewClientWithSecurityToken(accessKeyId, accessKeySecret, "")
+}
+
+func NewClientWithSecurityToken(accessKeyId string, accessKeySecret string, securityToken string) RamClientInterface {
 	endpoint := os.Getenv("RAM_ENDPOINT")
 	if endpoint == "" {
 		endpoint = RAMDefaultEndpoint
 	}
-	return NewClientWithEndpoint(endpoint, accessKeyId, accessKeySecret)
+
+	return NewClientWithEndpointAndSecurityToken(endpoint, accessKeyId, accessKeySecret, securityToken)
 }
 
 func NewClientWithEndpoint(endpoint string, accessKeyId string, accessKeySecret string) RamClientInterface {
+	return NewClientWithEndpointAndSecurityToken(endpoint, accessKeyId, accessKeySecret, "")
+}
+
+func NewClientWithEndpointAndSecurityToken(endpoint string, accessKeyId string, accessKeySecret string, securityToken string) RamClientInterface {
 	client := &RamClient{}
-	client.Init(endpoint, RAMAPIVersion, accessKeyId, accessKeySecret)
+	client.WithEndpoint(endpoint).
+		WithEndpoint(endpoint).
+		WithVersion(RAMAPIVersion).
+		WithAccessKeyId(accessKeyId).
+		WithAccessKeySecret(accessKeySecret).
+		WithSecurityToken(securityToken).
+		InitClient()
 	return client
 }

--- a/ram/client.go
+++ b/ram/client.go
@@ -36,7 +36,6 @@ func NewClientWithEndpoint(endpoint string, accessKeyId string, accessKeySecret 
 func NewClientWithEndpointAndSecurityToken(endpoint string, accessKeyId string, accessKeySecret string, securityToken string) RamClientInterface {
 	client := &RamClient{}
 	client.WithEndpoint(endpoint).
-		WithEndpoint(endpoint).
 		WithVersion(RAMAPIVersion).
 		WithAccessKeyId(accessKeyId).
 		WithAccessKeySecret(accessKeySecret).

--- a/sts/assume_role_test.go
+++ b/sts/assume_role_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/denverdino/aliyungo/ecs"
 	"github.com/denverdino/aliyungo/ram"
 )
 
@@ -136,6 +137,25 @@ func TestAssumeRole(t *testing.T) {
 		t.Errorf("Failed to AssumeRole %v", err)
 		return
 	}
+
+	ecsClient := ecs.NewECSClientWithSecurityToken(resp.Credentials.AccessKeyId, resp.Credentials.AccessKeySecret, resp.Credentials.SecurityToken, "")
+	_, err = ecsClient.DescribeRegions()
+	if err != nil {
+		t.Errorf("Failed to DescribeRegions %v", err)
+		return
+	}
+
+	ramClient = ram.NewClientWithSecurityToken(resp.Credentials.AccessKeyId, resp.Credentials.AccessKeySecret, resp.Credentials.SecurityToken)
+	req2 := ram.ListUserRequest{
+		Marker:   "",
+		MaxItems: 2,
+	}
+	_, err = ramClient.ListUsers(req2)
+	if err != nil {
+		t.Errorf("Failed to ListUsers %v", err)
+		return
+	}
+
 	t.Logf("pass AssumeRole %v", resp)
 
 }

--- a/sts/client.go
+++ b/sts/client.go
@@ -17,15 +17,30 @@ type STSClient struct {
 }
 
 func NewClient(accessKeyId string, accessKeySecret string) *STSClient {
+	return NewClientWithSecurityToken(accessKeyId, accessKeySecret, "")
+}
+
+func NewClientWithSecurityToken(accessKeyId string, accessKeySecret string, securityToken string) *STSClient {
 	endpoint := os.Getenv("STS_ENDPOINT")
 	if endpoint == "" {
 		endpoint = STSDefaultEndpoint
 	}
-	return NewClientWithEndpoint(endpoint, accessKeyId, accessKeySecret)
+
+	return NewClientWithEndpointAndSecurityToken(endpoint, accessKeyId, accessKeySecret, securityToken)
 }
 
 func NewClientWithEndpoint(endpoint string, accessKeyId string, accessKeySecret string) *STSClient {
+	return NewClientWithEndpointAndSecurityToken(endpoint, accessKeyId, accessKeySecret, "")
+}
+
+func NewClientWithEndpointAndSecurityToken(endpoint string, accessKeyId string, accessKeySecret string, securityToken string) *STSClient {
 	client := &STSClient{}
-	client.Init(endpoint, STSAPIVersion, accessKeyId, accessKeySecret)
+	client.WithEndpoint(endpoint).
+		WithEndpoint(endpoint).
+		WithVersion(STSAPIVersion).
+		WithAccessKeyId(accessKeyId).
+		WithAccessKeySecret(accessKeySecret).
+		WithSecurityToken(securityToken).
+		InitClient()
 	return client
 }

--- a/sts/client.go
+++ b/sts/client.go
@@ -36,7 +36,6 @@ func NewClientWithEndpoint(endpoint string, accessKeyId string, accessKeySecret 
 func NewClientWithEndpointAndSecurityToken(endpoint string, accessKeyId string, accessKeySecret string, securityToken string) *STSClient {
 	client := &STSClient{}
 	client.WithEndpoint(endpoint).
-		WithEndpoint(endpoint).
 		WithVersion(STSAPIVersion).
 		WithAccessKeyId(accessKeyId).
 		WithAccessKeySecret(accessKeySecret).

--- a/sts/get_caller_identity.go
+++ b/sts/get_caller_identity.go
@@ -1,0 +1,22 @@
+package sts
+
+import "github.com/denverdino/aliyungo/common"
+
+type GetCallerIdentityRequest struct {
+}
+
+type GetCallerIdentityResponse struct {
+	common.Response
+	AccountId string
+	UserId    string
+	Arn       string
+}
+
+func (c *STSClient) GetCallerIdentity() (*GetCallerIdentityResponse, error) {
+	resp := &GetCallerIdentityResponse{}
+	err := c.Invoke("GetCallerIdentity", &GetCallerIdentityRequest{}, resp)
+	if err != nil {
+		return resp, err
+	}
+	return resp, nil
+}

--- a/sts/get_caller_identity_test.go
+++ b/sts/get_caller_identity_test.go
@@ -1,0 +1,15 @@
+package sts
+
+import "testing"
+
+func TestGetCallerIdentity(t *testing.T) {
+
+	stsClient := NewTestClient()
+	resp, err := stsClient.GetCallerIdentity()
+	if err != nil {
+		t.Errorf("Failed to GetCallerIdentity %v", err)
+		return
+	}
+
+	t.Logf("pass GetCallerIdentity %v", resp)
+}


### PR DESCRIPTION
1. Support to create Clients from credentials of assumed role and fix issue #204.
2. Add API: sts.STSClient.GetCallerIdentity().
3. Add RegionID as request parameter.