### PR TITLE
Enable InternetMaxBandwitdh=0

### DIFF
--- a/ess/configuration.go
+++ b/ess/configuration.go
@@ -15,7 +15,7 @@ type CreateScalingConfigurationArgs struct {
 	ScalingConfigurationName string
 	InternetChargeType       common.InternetChargeType
 	InternetMaxBandwidthIn   int
-	InternetMaxBandwidthOut  int
+	InternetMaxBandwidthOut  *int
 	SystemDisk_Category      common.UnderlineString
 	SystemDisk_Size          common.UnderlineString
 	DataDisk                 []DataDiskType


### PR DESCRIPTION
Enabling setting InternetMaxBandwitdh to 0 so we can create scaling group instances without public IP