### PR TITLE
Fix cs api call failure issue, move some debug info into debug mode.

### DIFF
--- a/cs/client.go
+++ b/cs/client.go
@@ -133,7 +133,7 @@ func (client *Client) Invoke(region common.Region, method string, path string, q
 	// TODO move to util and add build val flag
 	httpReq.Header.Set("Date", util.GetGMTime())
 	httpReq.Header.Set("Accept", "application/json")
-	//httpReq.Header.Set("x-acs-version", client.Version)
+	httpReq.Header["x-acs-version"] = []string{client.Version}
 	httpReq.Header["x-acs-signature-version"] = []string{"1.0"}
 	httpReq.Header["x-acs-signature-nonce"] = []string{util.CreateRandomString()}
 	httpReq.Header["x-acs-signature-method"] = []string{"HMAC-SHA1"}

--- a/oss/client.go
+++ b/oss/client.go
@@ -1100,7 +1100,7 @@ func (client *Client) setupHttpRequest(req *request) (*http.Request, error) {
 // body will be unmarshalled on it.
 func (client *Client) doHttpRequest(c *http.Client, hreq *http.Request, resp interface{}) (*http.Response, error) {
 
-	if true {
+	if client.debug {
 		log.Printf("%s %s ...\n", hreq.Method, hreq.URL.String())
 	}
 	hresp, err := c.Do(hreq)


### PR DESCRIPTION

if we do not add header `x-acs-version`, it will response as following.

```json
{
    "Recommend": "https://error-center.aliyun.com/status/search?Keyword=InvalidAction.NotFound&source=PopGw",
    "Message": "Specified api is not found, please check your url and method.",
    "RequestId": "0C922E89-2F00-41CE-AB9F-8014157F9B2E",
    "HostId": "cs.aliyuncs.com",
    "Code": "InvalidAction.NotFound"
}  
```