### PR TITLE
Use AssociateEipAddressArgs as AssociateEipAddress parameter

### DIFF
--- a/ecs/networks.go
+++ b/ecs/networks.go
@@ -104,12 +104,8 @@ type AssociateEipAddressResponse struct {
 
 // AssociateEipAddress associates EIP address to VM instance
 //
-// You can read doc at http://docs.aliyun.com/#/pub/ecs/open-api/network&associateeipaddress
-func (client *Client) AssociateEipAddress(allocationId string, instanceId string) error {
-	args := AssociateEipAddressArgs{
-		AllocationId: allocationId,
-		InstanceId:   instanceId,
-	}
+// You can read doc at https://help.aliyun.com/document_detail/36017.html
+func (client *Client) AssociateEipAddress(args *AssociateEipAddressArgs) error {
 	response := ModifyInstanceNetworkSpecResponse{}
 	return client.Invoke("AssociateEipAddress", &args, &response)
 }

--- a/ecs/networks.go
+++ b/ecs/networks.go
@@ -216,6 +216,7 @@ func (client *Client) ModifyEipAddressAttribute(allocationId string, bandwidth i
 type UnallocateEipAddressArgs struct {
 	AllocationId string
 	InstanceId   string
+	InstanceType EipInstanceType
 }
 
 type UnallocateEipAddressResponse struct {
@@ -224,12 +225,8 @@ type UnallocateEipAddressResponse struct {
 
 // UnassociateEipAddress unallocates Eip Address from instance
 //
-// You can read doc at http://docs.aliyun.com/#/pub/ecs/open-api/network&unassociateeipaddress
-func (client *Client) UnassociateEipAddress(allocationId string, instanceId string) error {
-	args := UnallocateEipAddressArgs{
-		AllocationId: allocationId,
-		InstanceId:   instanceId,
-	}
+// You can read doc at https://help.aliyun.com/document_detail/36021.html
+func (client *Client) UnassociateEipAddress(args *UnallocateEipAddressArgs) error {
 	response := UnallocateEipAddressResponse{}
 	return client.Invoke("UnassociateEipAddress", &args, &response)
 }

--- a/ecs/networks_test.go
+++ b/ecs/networks_test.go
@@ -42,7 +42,11 @@ func testEipAddress(t *testing.T, client *Client, regionId common.Region, instan
 		t.Errorf("Failed to wait EIP %s: %v", allocationId, err)
 	}
 
-	err = client.AssociateEipAddress(allocationId, instanceId)
+	err = client.AssociateEipAddress(&AssociateEipAddressArgs{
+		AllocationId: allocationId,
+		InstanceId:   instanceId,
+		InstanceType: EcsInstance,
+	})
 	if err != nil {
 		t.Errorf("Failed to associate EIP address: %v", err)
 	}
@@ -50,7 +54,11 @@ func testEipAddress(t *testing.T, client *Client, regionId common.Region, instan
 	if err != nil {
 		t.Errorf("Failed to wait EIP %s: %v", allocationId, err)
 	}
-	err = client.UnassociateEipAddress(allocationId, instanceId)
+	err = client.UnassociateEipAddress(&UnallocateEipAddressArgs{
+		AllocationId: allocationId,
+		InstanceId:   instanceId,
+		InstanceType: EcsInstance,
+	})
 	if err != nil {
 		t.Errorf("Failed to unassociate EIP address: %v", err)
 	}


### PR DESCRIPTION
This PR changes `AssociateEipAddress` parameters from `(allocationId string, instanceId string)` to `(args *AssociateEipAddressArgs)` that prevent a failure of associating EIP to NAT gateway (or other types).

The official document assumes `EcsInstance` as default `InstanceType` of the request. The API of `AssociateEipAddress`, only allow users passing `allocationId` and instanceId for associating two instances. This may leads an failure of associating EIP to NAT gateway or another instace type instead of ECS type.

More detail can be verified in: https://help.aliyun.com/document_detail/36017.html