### PR TITLE
support kubernetes cluster multiaz creation

### DIFF
--- a/cs/clusters.go
+++ b/cs/clusters.go
@@ -134,6 +134,43 @@ type KubernetesCreationArgs struct {
 	StackParams       KubernetesStackArgs `json:"stack_params"`
 }
 
+type KubernetesMultiAZCreationArgs struct {
+	DisableRollback          bool             `json:"disable_rollback"`
+	Name                     string           `json:"name"`
+	TimeoutMins              int64            `json:"timeout_mins"`
+	ClusterType              string           `json:"cluster_type"`
+	MultiAZ                  bool             `json:"multi_az,omitempty"`
+	VPCID                    string           `json:"vpcid,omitempty"`
+	ContainerCIDR            string           `json:"container_cidr"`
+	ServiceCIDR              string           `json:"service_cidr"`
+	VSwitchIdA               string           `json:"vswitch_id_a,omitempty"`
+	VSwitchIdB               string           `json:"vswitch_id_b,omitempty"`
+	VSwitchIdC               string           `json:"vswitch_id_c,omitempty"`
+	MasterInstanceTypeA      string           `json:"master_instance_type_a,omitempty"`
+	MasterInstanceTypeB      string           `json:"master_instance_type_b,omitempty"`
+	MasterInstanceTypeC      string           `json:"master_instance_type_c,omitempty"`
+	MasterSystemDiskSize     int64            `json:"master_system_disk_size"`
+	MasterSystemDiskCategory ecs.DiskCategory `json:"master_system_disk_category"`
+	WorkerInstanceTypeA      string           `json:"worker_instance_type_a,omitempty"`
+	WorkerInstanceTypeB      string           `json:"worker_instance_type_b,omitempty"`
+	WorkerInstanceTypeC      string           `json:"worker_instance_type_c,omitempty"`
+	WorkerSystemDiskSize     int64            `json:"worker_system_disk_size"`
+	WorkerSystemDiskCategory ecs.DiskCategory `json:"worker_system_disk_category"`
+	NumOfNodesA              int64            `json:"num_of_nodes_a"`
+	NumOfNodesB              int64            `json:"num_of_nodes_b"`
+	NumOfNodesC              int64            `json:"num_of_nodes_c"`
+	SSHFlags                 bool             `json:"ssh_flags"`
+	CloudMonitorFlags        bool             `json:"cloud_monitor_flags"`
+	LoginPassword            string           `json:"login_password,omitempty"`
+	ImageId                  string           `json:"image_id,omitempty"`
+	KeyPair                  string           `json:"key_pair,omitempty"`
+}
+
+func (client *Client) CreateKubernetesMultiAZCluster(region common.Region, args *KubernetesMultiAZCreationArgs) (cluster ClusterCreationResponse, err error) {
+	err = client.Invoke(region, http.MethodPost, "/clusters", nil, args, &cluster)
+	return
+}
+
 func (client *Client) CreateKubernetesCluster(region common.Region, args *KubernetesCreationArgs) (cluster ClusterCreationResponse, err error) {
 	err = client.Invoke(region, http.MethodPost, "/clusters", nil, args, &cluster)
 	return

--- a/cs/clusters_test.go
+++ b/cs/clusters_test.go
@@ -87,3 +87,42 @@ func _TestDeleteClusters(t *testing.T) {
 	}
 	t.Logf("Cluster %s is deleting", clusterId)
 }
+
+func _TestCreateKubernetesMultiAZCluster(t *testing.T) {
+
+	client := NewTestClientForDebug()
+
+	args := KubernetesMultiAZCreationArgs{
+		Name:                     "multiaz-test",
+		ClusterType:              "Kubernetes",
+		DisableRollback:          true,
+		MultiAZ:                  true,
+		VPCID:                    "vpc-test",
+		VSwitchIdA:               "vsw-test",
+		VSwitchIdB:               "vsw-test",
+		VSwitchIdC:               "vsw-test",
+		NumOfNodesA:              1,
+		NumOfNodesB:              2,
+		NumOfNodesC:              3,
+		MasterInstanceTypeA:      "ecs.sn1ne.large",
+		MasterInstanceTypeB:      "ecs.sn1ne.large",
+		MasterInstanceTypeC:      "ecs.sn1ne.large",
+		MasterSystemDiskCategory: "cloud_efficiency",
+		MasterSystemDiskSize:     40,
+		WorkerInstanceTypeA:      "ecs.sn1ne.large",
+		WorkerInstanceTypeB:      "ecs.sn1ne.large",
+		WorkerInstanceTypeC:      "ecs.sn1ne.large",
+		WorkerSystemDiskCategory: "cloud_efficiency",
+		WorkerSystemDiskSize:     40,
+		SSHFlags:                 true,
+		ContainerCIDR:            "172.16.0.0/16",
+		ServiceCIDR:              "172.19.0.0/20",
+		LoginPassword:            "test-password",
+	}
+	cluster, err := client.CreateKubernetesMultiAZCluster(common.Hangzhou, &args)
+	if err != nil {
+		t.Fatalf("Failed to CreateCluster: %v", err)
+	}
+
+	t.Logf("Cluster: %++v", cluster)
+}


### PR DESCRIPTION
Added support for Kubernetes Cluster MultiAZ creation.

Cluster creation's API style had been changed, most parameters are now placed under the root key, instead of the `stack_params` key.

So I made a new method `CreateKubernetesMultiAZCluster` and a new struct `KubernetesMultiAZCreationArgs`  to create multiaz cluster, not touching the old-sytle API.

API Doc is located at https://help.aliyun.com/document_detail/73987.html



