### PR TITLE
support new-style api for container service

### DIFF
--- a/cs/clusters.go
+++ b/cs/clusters.go
@@ -10,6 +10,7 @@ import (
 
 	"fmt"
 
+	"encoding/json"
 	"github.com/denverdino/aliyungo/common"
 	"github.com/denverdino/aliyungo/ecs"
 )
@@ -42,22 +43,23 @@ const (
 
 // https://help.aliyun.com/document_detail/26053.html
 type ClusterType struct {
-	AgentVersion           string           `json:"agent_version"`
-	ClusterID              string           `json:"cluster_id"`
-	Name                   string           `json:"name"`
-	Created                time.Time  `json:"created"`
-	ExternalLoadbalancerID string           `json:"external_loadbalancer_id"`
-	MasterURL              string           `json:"master_url"`
-	NetworkMode            NetworkModeType  `json:"network_mode"`
-	RegionID               common.Region    `json:"region_id"`
-	SecurityGroupID        string           `json:"security_group_id"`
-	Size                   int64            `json:"size"`
-	State                  ClusterState     `json:"state"`
-	Updated                time.Time `json:"updated"`
-	VPCID                  string           `json:"vpc_id"`
-	VSwitchID              string           `json:"vswitch_id"`
-	NodeStatus             string           `json:"node_status"`
-	DockerVersion          string           `json:"docker_version"`
+	AgentVersion           string          `json:"agent_version"`
+	ClusterID              string          `json:"cluster_id"`
+	Name                   string          `json:"name"`
+	Created                time.Time       `json:"created"`
+	ExternalLoadbalancerID string          `json:"external_loadbalancer_id"`
+	MasterURL              string          `json:"master_url"`
+	NetworkMode            NetworkModeType `json:"network_mode"`
+	RegionID               common.Region   `json:"region_id"`
+	SecurityGroupID        string          `json:"security_group_id"`
+	Size                   int64           `json:"size"`
+	State                  ClusterState    `json:"state"`
+	Updated                time.Time       `json:"updated"`
+	VPCID                  string          `json:"vpc_id"`
+	VSwitchID              string          `json:"vswitch_id"`
+	NodeStatus             string          `json:"node_status"`
+	DockerVersion          string          `json:"docker_version"`
+	ClusterType            string          `json:"cluster_type"`
 }
 
 func (client *Client) DescribeClusters(nameFilter string) (clusters []ClusterType, err error) {
@@ -102,35 +104,56 @@ func (client *Client) CreateCluster(region common.Region, args *ClusterCreationA
 	return
 }
 
+// Deprecated
 type KubernetesStackArgs struct {
 	VPCID                    string           `json:"VpcId,omitempty"`
 	VSwitchID                string           `json:"VSwitchId,omitempty"`
-	MasterInstanceType       string           `json:"MasterInstanceType"`
-	WorkerInstanceType       string           `json:"WorkerInstanceType"`
-	NumOfNodes               int64            `json:"NumOfNodes"`
-	Password                 string           `json:"LoginPassword"`
-	DockerVersion            string           `json:"DockerVersion"`
-	KubernetesVersion        string           `json:"KubernetesVersion"`
-	ZoneId                   string           `json:"ZoneId"`
-	ContainerCIDR            string           `json:"ContainerCIDR"`
-	ServiceCIDR              string           `json:"ServiceCIDR"`
-	SSHFlags                 bool             `json:"SSHFlags"`
-	MasterSystemDiskSize     int64            `json:"MasterSystemDiskSize"`
-	MasterSystemDiskCategory ecs.DiskCategory `json:"MasterSystemDiskCategory"`
-	WorkerSystemDiskSize     int64            `json:"WorkerSystemDiskSize"`
-	WorkerSystemDiskCategory ecs.DiskCategory `json:"WorkerSystemDiskCategory"`
+	MasterInstanceType       string           `json:"MasterInstanceType,omitempty"`
+	WorkerInstanceType       string           `json:"WorkerInstanceType,omitempty"`
+	NumOfNodes               int64            `json:"NumOfNodes,omitempty"`
+	Password                 string           `json:"LoginPassword,omitempty"`
+	DockerVersion            string           `json:"DockerVersion,omitempty"`
+	KubernetesVersion        string           `json:"KubernetesVersion,omitempty"`
+	ZoneId                   string           `json:"ZoneId,omitempty"`
+	ContainerCIDR            string           `json:"ContainerCIDR,omitempty"`
+	ServiceCIDR              string           `json:"ServiceCIDR,omitempty"`
+	SSHFlags                 bool             `json:"SSHFlags,omitempty"`
+	MasterSystemDiskSize     int64            `json:"MasterSystemDiskSize,omitempty"`
+	MasterSystemDiskCategory ecs.DiskCategory `json:"MasterSystemDiskCategory,omitempty"`
+	WorkerSystemDiskSize     int64            `json:"WorkerSystemDiskSize,omitempty"`
+	WorkerSystemDiskCategory ecs.DiskCategory `json:"WorkerSystemDiskCategory,omitempty"`
 	ImageID                  string           `json:"ImageId,omitempty"`
-	CloudMonitorFlags        bool             `json:"CloudMonitorFlags"`
-	SNatEntry                bool             `json:"SNatEntry"`
+	CloudMonitorFlags        bool             `json:"CloudMonitorFlags,omitempty"`
+	SNatEntry                bool             `json:"SNatEntry,omitempty"`
 }
 
 type KubernetesCreationArgs struct {
-	ClusterType       string              `json:"cluster_type"`
-	Name              string              `json:"name"`
-	DisableRollback   bool                `json:"disable_rollback"`
-	TimeoutMins       int64               `json:"timeout_mins"`
-	KubernetesVersion string              `json:"kubernetes_version"`
-	StackParams       KubernetesStackArgs `json:"stack_params"`
+	DisableRollback          bool             `json:"disable_rollback"`
+	Name                     string           `json:"name"`
+	TimeoutMins              int64            `json:"timeout_mins"`
+	ZoneId                   string           `json:"zoneid,omitempty"`
+	VPCID                    string           `json:"vpcid,omitempty"`
+	VSwitchId                string           `json:"vswitchid,omitempty"`
+	ContainerCIDR            string           `json:"container_cidr,omitempty"`
+	ServiceCIDR              string           `json:"service_cidr,omitempty"`
+	MasterInstanceType       string           `json:"master_instance_type,omitempty"`
+	MasterSystemDiskSize     int64            `json:"master_system_disk_size,omitempty"`
+	MasterSystemDiskCategory ecs.DiskCategory `json:"master_system_disk_category,omitempty"`
+	WorkerInstanceType       string           `json:"worker_instance_type,omitempty"`
+	WorkerSystemDiskSize     int64            `json:"worker_system_disk_size,omitempty"`
+	WorkerSystemDiskCategory ecs.DiskCategory `json:"worker_system_disk_category,omitempty"`
+	LoginPassword            string           `json:"login_password,omitempty"`
+	KeyPair                  string           `json:"key_pair,omitempty"`
+	NumOfNodes               int64            `json:"num_of_nodes,omitempty"`
+	SNatEntry                bool             `json:"snat_entry,omitempty"`
+	SSHFlags                 bool             `json:"ssh_flags,omitempty"`
+	CloudMonitorFlags        bool             `json:"cloud_monitor_flags,omitempty"`
+
+	ClusterType string `json:"cluster_type"`
+	Network     string `json:"network,omitempty"`
+
+	KubernetesVersion string              `json:"kubernetes_version,omitempty"`
+	StackParams       KubernetesStackArgs `json:"stack_params,omitempty"`
 }
 
 type KubernetesMultiAZCreationArgs struct {
@@ -148,21 +171,23 @@ type KubernetesMultiAZCreationArgs struct {
 	MasterInstanceTypeA      string           `json:"master_instance_type_a,omitempty"`
 	MasterInstanceTypeB      string           `json:"master_instance_type_b,omitempty"`
 	MasterInstanceTypeC      string           `json:"master_instance_type_c,omitempty"`
-	MasterSystemDiskSize     int64            `json:"master_system_disk_size"`
 	MasterSystemDiskCategory ecs.DiskCategory `json:"master_system_disk_category"`
+	MasterSystemDiskSize     int64            `json:"master_system_disk_size"`
 	WorkerInstanceTypeA      string           `json:"worker_instance_type_a,omitempty"`
 	WorkerInstanceTypeB      string           `json:"worker_instance_type_b,omitempty"`
 	WorkerInstanceTypeC      string           `json:"worker_instance_type_c,omitempty"`
-	WorkerSystemDiskSize     int64            `json:"worker_system_disk_size"`
 	WorkerSystemDiskCategory ecs.DiskCategory `json:"worker_system_disk_category"`
+	WorkerSystemDiskSize     int64            `json:"worker_system_disk_size"`
 	NumOfNodesA              int64            `json:"num_of_nodes_a"`
 	NumOfNodesB              int64            `json:"num_of_nodes_b"`
 	NumOfNodesC              int64            `json:"num_of_nodes_c"`
+	LoginPassword            string           `json:"login_password,omitempty"`
+	KeyPair                  string           `json:"key_pair,omitempty"`
 	SSHFlags                 bool             `json:"ssh_flags"`
 	CloudMonitorFlags        bool             `json:"cloud_monitor_flags"`
-	LoginPassword            string           `json:"login_password,omitempty"`
-	ImageId                  string           `json:"image_id,omitempty"`
-	KeyPair                  string           `json:"key_pair,omitempty"`
+
+	KubernetesVersion string `json:"kubernetes_version,omitempty"`
+	Network           string `json:"network,omitempty"`
 }
 
 func (client *Client) CreateKubernetesMultiAZCluster(region common.Region, args *KubernetesMultiAZCreationArgs) (cluster ClusterCreationResponse, err error) {
@@ -172,6 +197,89 @@ func (client *Client) CreateKubernetesMultiAZCluster(region common.Region, args 
 
 func (client *Client) CreateKubernetesCluster(region common.Region, args *KubernetesCreationArgs) (cluster ClusterCreationResponse, err error) {
 	err = client.Invoke(region, http.MethodPost, "/clusters", nil, args, &cluster)
+	return
+}
+
+type KubernetesClusterMetaData struct {
+	DockerVersion     string `json:"DockerVersion"`
+	EtcdVersion       string `json:"EtcdVersion"`
+	KubernetesVersion string `json:"KubernetesVersion"`
+	MultiAZ           bool   `json:"MultiAZ"`
+	SubClass          string `json:"SubClass"`
+}
+
+type KubernetesClusterParameter struct {
+	ServiceCidr              string `json:"ServiceCIDR"`
+	ContainerCidr            string `json:"ContainerCIDR"`
+	DockerVersion            string `json:"DockerVersion"`
+	EtcdVersion              string `json:"EtcdVersion"`
+	KubernetesVersion        string `json:"KubernetesVersion"`
+	VPCID                    string `json:"VpcId"`
+	MasterSystemDiskCategory string `json:"MasterSystemDiskCategory"`
+	MasterSystemDiskSize     string `json:"MasterSystemDiskSize"`
+	WorkerSystemDiskCategory string `json:"WorkerSystemDiskCategory"`
+	WorkerSystemDiskSize     string `json:"WorkerSystemDiskSize"`
+	ZoneId                   string `json:"ZoneId"`
+
+	// Single AZ
+	MasterInstanceType string `json:"MasterInstanceType"`
+	WorkerInstanceType string `json:"WorkerInstanceType"`
+	NumOfNodes         string `json:"NumOfNodes"`
+	VSwitchID          string `json:"VSwitchId"`
+
+	// Multi AZ
+	MasterInstanceTypeA string `json:"MasterInstanceTypeA"`
+	MasterInstanceTypeB string `json:"MasterInstanceTypeB"`
+	MasterInstanceTypeC string `json:"MasterInstanceTypeC"`
+	WorkerInstanceTypeA string `json:"WorkerInstanceTypeA"`
+	WorkerInstanceTypeB string `json:"WorkerInstanceTypeB"`
+	WorkerInstanceTypeC string `json:"WorkerInstanceTypeC"`
+	NumOfNodesA         string `json:"NumOfNodesA"`
+	NumOfNodesB         string `json:"NumOfNodesB"`
+	NumOfNodesC         string `json:"NumOfNodesC"`
+	VSwitchIdA          string `json:"VSwitchIdA"`
+	VSwitchIdB          string `json:"VSwitchIdB"`
+	VSwitchIdC          string `json:"VSwitchIdC"`
+}
+
+type KubernetesCluster struct {
+	ClusterType
+
+	AgentVersion    string          `json:"agent_version"`
+	ClusterID       string          `json:"cluster_id"`
+	Name            string          `json:"name"`
+	Created         time.Time       `json:"created"`
+	MasterURL       string          `json:"master_url"`
+	NetworkMode     NetworkModeType `json:"network_mode"`
+	RegionID        common.Region   `json:"region_id"`
+	SecurityGroupID string          `json:"security_group_id"`
+	Size            int64           `json:"size"`
+	State           ClusterState    `json:"state"`
+	Updated         time.Time       `json:"updated"`
+	VPCID           string          `json:"vpc_id"`
+	VSwitchID       string          `json:"vswitch_id"`
+	NodeStatus      string          `json:"node_status"`
+	DockerVersion   string          `json:"docker_version"`
+
+	ZoneId                 string `json:"zone_id"`
+	RawMetaData            string `json:"meta_data,omitempty"`
+	MetaData               KubernetesClusterMetaData
+	InitVersion            string `json:"init_version"`
+	CurrentVersion         string `json:"current_version"`
+	ExternalLoadbalancerId string `json:"external_loadbalancer_id"`
+
+	Parameters KubernetesClusterParameter `json:"parameters"`
+}
+
+func (client *Client) DescribeKubernetesCluster(id string) (cluster KubernetesCluster, err error) {
+	err = client.Invoke("", http.MethodGet, "/clusters/"+id, nil, nil, &cluster)
+	if err != nil {
+		return cluster, err
+	}
+	var metaData KubernetesClusterMetaData
+	err = json.Unmarshal([]byte(cluster.RawMetaData), &metaData)
+	cluster.MetaData = metaData
+	cluster.RawMetaData = ""
 	return
 }
 
@@ -193,7 +301,31 @@ func (client *Client) ResizeCluster(clusterID string, args *ClusterResizeArgs) e
 	return client.Invoke("", http.MethodPut, "/clusters/"+clusterID, nil, args, nil)
 }
 
+// deprecated
+// use ResizeKubernetesCluster instead
 func (client *Client) ResizeKubernetes(clusterID string, args *KubernetesCreationArgs) error {
+	return client.Invoke("", http.MethodPut, "/clusters/"+clusterID, nil, args, nil)
+}
+
+type KubernetesClusterResizeArgs struct {
+	DisableRollback bool   `json:"disable_rollback"`
+	TimeoutMins     int64  `json:"timeout_mins"`
+	LoginPassword   string `json:"login_password,omitempty"`
+
+	// Single AZ
+	WorkerInstanceType string `json:"worker_instance_type"`
+	NumOfNodes         int64  `json:"num_of_nodes"`
+
+	// Multi AZ
+	WorkerInstanceTypeA string `json:"worker_instance_type_a"`
+	WorkerInstanceTypeB string `json:"worker_instance_type_b"`
+	WorkerInstanceTypeC string `json:"worker_instance_type_c"`
+	NumOfNodesA         int64  `json:"num_of_nodes_a"`
+	NumOfNodesB         int64  `json:"num_of_nodes_b"`
+	NumOfNodesC         int64  `json:"num_of_nodes_c"`
+}
+
+func (client *Client) ResizeKubernetesCluster(clusterID string, args *KubernetesClusterResizeArgs) error {
 	return client.Invoke("", http.MethodPut, "/clusters/"+clusterID, nil, args, nil)
 }
 

--- a/cs/clusters_test.go
+++ b/cs/clusters_test.go
@@ -32,6 +32,46 @@ func TestClient_DescribeClusters(t *testing.T) {
 	}
 }
 
+func TestClient_DescribeKubernetesClusters(t *testing.T) {
+
+	client := NewTestDebugAussumeRoleClient()
+
+	clusters, err := client.DescribeClusters("")
+	if err != nil {
+		t.Fatalf("Failed to DescribeClusters: %v", err)
+	}
+
+	for _, cluster := range clusters {
+		if cluster.ClusterType != "Kubernetes" {
+			continue
+		}
+		t.Logf("Cluster: %++v", cluster)
+		c, err := client.DescribeKubernetesCluster(cluster.ClusterID)
+		if err != nil {
+			t.Errorf("Failed to DescribeCluster: %v", err)
+		}
+		t.Logf("Cluster Describe: %++v", c)
+
+		if c.MetaData.MultiAZ || c.MetaData.SubClass == "3az" {
+			t.Logf("%v is a MultiAZ kubernetes cluster", c.ClusterID)
+			t.Logf("Cluster VSWA ID %v", c.Parameters.VSwitchIdA)
+			t.Logf("Cluster VSWB ID %v", c.Parameters.VSwitchIdB)
+			t.Logf("Cluster VSWC ID %v", c.Parameters.VSwitchIdC)
+			t.Logf("Cluster MasterInstanceTypeA %v", c.Parameters.MasterInstanceTypeA)
+			t.Logf("Cluster MasterInstanceTypeB %v", c.Parameters.MasterInstanceTypeB)
+			t.Logf("Cluster MasterInstanceTypeC %v", c.Parameters.MasterInstanceTypeC)
+			t.Logf("Cluster NumOfNodeA %v", c.Parameters.NumOfNodesA)
+			t.Logf("Cluster NumOfNodeB %v", c.Parameters.NumOfNodesB)
+			t.Logf("Cluster NumOfNodeC %v", c.Parameters.NumOfNodesC)
+		} else {
+			t.Logf("%v is a single kubernetes cluster", c.ClusterID)
+			t.Logf("Cluster VSW ID %v", c.Parameters.VSwitchID)
+			t.Logf("Cluster MasterInstanceType %v", c.Parameters.MasterInstanceType)
+			t.Logf("Cluster NumOfNode %v", c.Parameters.NumOfNodes)
+		}
+	}
+}
+
 func TestListClusters(t *testing.T) {
 
 	client := NewTestClientForDebug()
@@ -88,22 +128,54 @@ func _TestDeleteClusters(t *testing.T) {
 	t.Logf("Cluster %s is deleting", clusterId)
 }
 
+func _TestCreateKubernetesCluster(t *testing.T) {
+
+	client := NewTestClientForDebug()
+
+	args := KubernetesCreationArgs{
+		Name:            "single-az-k8s",
+		ClusterType:     "Kubernetes",
+		DisableRollback: true,
+		//VPCID:                    "vpc-id",
+		//VSwitchId:                "vsw-id",
+		ZoneId:                   "cn-hangzhou-g",
+		SNatEntry:                true,
+		NumOfNodes:               1,
+		MasterInstanceType:       "ecs.sn1ne.large",
+		MasterSystemDiskCategory: "cloud_efficiency",
+		MasterSystemDiskSize:     40,
+		WorkerInstanceType:       "ecs.sn1ne.large",
+		WorkerSystemDiskCategory: "cloud_efficiency",
+		WorkerSystemDiskSize:     40,
+		SSHFlags:                 true,
+		ContainerCIDR:            "172.16.0.0/16",
+		ServiceCIDR:              "172.19.0.0/20",
+		LoginPassword:            "test-password123",
+	}
+	cluster, err := client.CreateKubernetesCluster(common.Hangzhou, &args)
+	if err != nil {
+		t.Fatalf("Failed to CreateKubernetesCluster: %v", err)
+	}
+
+	t.Logf("Cluster: %++v", cluster)
+}
+
 func _TestCreateKubernetesMultiAZCluster(t *testing.T) {
 
 	client := NewTestClientForDebug()
 
 	args := KubernetesMultiAZCreationArgs{
-		Name:                     "multiaz-test",
+		Name:                     "multiaz-test1",
 		ClusterType:              "Kubernetes",
 		DisableRollback:          true,
 		MultiAZ:                  true,
-		VPCID:                    "vpc-test",
-		VSwitchIdA:               "vsw-test",
-		VSwitchIdB:               "vsw-test",
-		VSwitchIdC:               "vsw-test",
+		VPCID:                    "vpc-id",
+		VSwitchIdA:               "vsw-id1",
+		VSwitchIdB:               "vsw-id2",
+		VSwitchIdC:               "vsw-id3",
 		NumOfNodesA:              1,
-		NumOfNodesB:              2,
-		NumOfNodesC:              3,
+		NumOfNodesB:              1,
+		NumOfNodesC:              1,
 		MasterInstanceTypeA:      "ecs.sn1ne.large",
 		MasterInstanceTypeB:      "ecs.sn1ne.large",
 		MasterInstanceTypeC:      "ecs.sn1ne.large",
@@ -115,14 +187,31 @@ func _TestCreateKubernetesMultiAZCluster(t *testing.T) {
 		WorkerSystemDiskCategory: "cloud_efficiency",
 		WorkerSystemDiskSize:     40,
 		SSHFlags:                 true,
-		ContainerCIDR:            "172.16.0.0/16",
-		ServiceCIDR:              "172.19.0.0/20",
-		LoginPassword:            "test-password",
+		ContainerCIDR:            "172.17.0.0/16",
+		ServiceCIDR:              "172.20.0.0/20",
+		LoginPassword:            "test-password123",
 	}
 	cluster, err := client.CreateKubernetesMultiAZCluster(common.Hangzhou, &args)
 	if err != nil {
-		t.Fatalf("Failed to CreateCluster: %v", err)
+		t.Fatalf("Failed to CreateKubernetesMultiAZCluster: %v", err)
 	}
 
 	t.Logf("Cluster: %++v", cluster)
+}
+
+func _TestResizeKubernetesCluster(t *testing.T) {
+	client := NewTestClientForDebug()
+
+	args := KubernetesClusterResizeArgs{
+		DisableRollback:    true,
+		TimeoutMins:        60,
+		LoginPassword:      "test-password123",
+		WorkerInstanceType: "ecs.sn1ne.large",
+		NumOfNodes:         2,
+	}
+
+	err := client.ResizeKubernetesCluster("c3419330390a94906bcacc55bfa9dd21f", &args)
+	if err != nil {
+		t.Fatalf("Failed to TestResizeKubernetesCluster: %v", err)
+	}
 }


### PR DESCRIPTION
What I've changed:
* Mark `KubernetesStackArgs`,`ResizeKubernetes` as deprecated
* Add `KubernetesVersion`, `Network` to `KubernetesMultiAZCreationArgs`
* Add `DescribeKubernetesCluster` to get details about a kubernetes cluster
* Add `ResizeKubernetesCluster` to support resizing of singleAZ/multiAZ cluster
