### PR TITLE
Add PublicSLB arg to K8S, remove lots of 'omitempty'

### DIFF
--- a/cs/clusters.go
+++ b/cs/clusters.go
@@ -92,7 +92,7 @@ type ClusterCreationArgs struct {
 	ECSImageID       string           `json:"ecs_image_id,omitempty"`
 	IOOptimized      ecs.IoOptimized  `json:"io_optimized"`
 	ReleaseEipFlag   bool             `json:"release_eip_flag"`
-	NeedSLB          bool             `json:"need_slb"` 
+	NeedSLB          bool             `json:"need_slb"`
 }
 
 type ClusterCreationResponse struct {
@@ -155,6 +155,7 @@ type KubernetesCreationArgs struct {
 	NodeCIDRMask             string           `json:"node_cidr_mask,omitempty"`
 	LoggingType              string           `json:"logging_type,omitempty"`
 	SLSProjectName           string           `json:"sls_project_name,omitempty"`
+	PublicSLB                bool             `json:"public_slb"`
 
 	ClusterType string `json:"cluster_type"`
 	Network     string `json:"network,omitempty"`
@@ -198,6 +199,7 @@ type KubernetesMultiAZCreationArgs struct {
 	NodeCIDRMask             string           `json:"node_cidr_mask,omitempty"`
 	LoggingType              string           `json:"logging_type,omitempty"`
 	SLSProjectName           string           `json:"sls_project_name,omitempty"`
+	PublicSLB                bool             `json:"public_slb"`
 
 	KubernetesVersion string `json:"kubernetes_version,omitempty"`
 	Network           string `json:"network,omitempty"`
@@ -241,6 +243,8 @@ type KubernetesClusterParameter struct {
 	NodeCIDRMask             string `json:"NodeCIDRMask"`
 	LoggingType              string `json:"LoggingType"`
 	SLSProjectName           string `json:"SLSProjectName"`
+	PublicSLB                bool
+	RawPublicSLB             string `json:"PublicSLB"`
 
 	// Single AZ
 	MasterInstanceType string `json:"MasterInstanceType"`
@@ -301,10 +305,17 @@ func (client *Client) DescribeKubernetesCluster(id string) (cluster KubernetesCl
 	err = json.Unmarshal([]byte(cluster.RawMetaData), &metaData)
 	cluster.MetaData = metaData
 	cluster.RawMetaData = ""
-	if cluster.Parameters.RawWorkerDataDisk == "True" {
-		cluster.Parameters.WorkerDataDisk = true
-	}
+	cluster.Parameters.WorkerDataDisk = convertStringToBool(cluster.Parameters.RawWorkerDataDisk)
+	cluster.Parameters.PublicSLB = convertStringToBool(cluster.Parameters.RawPublicSLB)
 	return
+}
+
+func convertStringToBool(raw string) bool {
+	if raw == "True" {
+		return true
+	} else {
+		return false
+	}
 }
 
 type ClusterResizeArgs struct {

--- a/cs/clusters.go
+++ b/cs/clusters.go
@@ -143,15 +143,15 @@ type KubernetesCreationArgs struct {
 	WorkerInstanceType       string           `json:"worker_instance_type,omitempty"`
 	WorkerSystemDiskSize     int64            `json:"worker_system_disk_size,omitempty"`
 	WorkerSystemDiskCategory ecs.DiskCategory `json:"worker_system_disk_category,omitempty"`
-	WorkerDataDisk           bool             `json:"worker_data_disk,omitempty"`
+	WorkerDataDisk           bool             `json:"worker_data_disk"`
 	WorkerDataDiskCategory   string           `json:"worker_data_disk_category,omitempty"`
 	WorkerDataDiskSize       int64            `json:"worker_data_disk_size,omitempty"`
 	LoginPassword            string           `json:"login_password,omitempty"`
 	KeyPair                  string           `json:"key_pair,omitempty"`
 	NumOfNodes               int64            `json:"num_of_nodes,omitempty"`
-	SNatEntry                bool             `json:"snat_entry,omitempty"`
-	SSHFlags                 bool             `json:"ssh_flags,omitempty"`
-	CloudMonitorFlags        bool             `json:"cloud_monitor_flags,omitempty"`
+	SNatEntry                bool             `json:"snat_entry"`
+	SSHFlags                 bool             `json:"ssh_flags"`
+	CloudMonitorFlags        bool             `json:"cloud_monitor_flags"`
 	NodeCIDRMask             string           `json:"node_cidr_mask,omitempty"`
 	LoggingType              string           `json:"logging_type,omitempty"`
 	SLSProjectName           string           `json:"sls_project_name,omitempty"`
@@ -168,7 +168,7 @@ type KubernetesMultiAZCreationArgs struct {
 	Name                     string           `json:"name"`
 	TimeoutMins              int64            `json:"timeout_mins"`
 	ClusterType              string           `json:"cluster_type"`
-	MultiAZ                  bool             `json:"multi_az,omitempty"`
+	MultiAZ                  bool             `json:"multi_az"`
 	VPCID                    string           `json:"vpcid,omitempty"`
 	ContainerCIDR            string           `json:"container_cidr"`
 	ServiceCIDR              string           `json:"service_cidr"`

--- a/cs/clusters_test.go
+++ b/cs/clusters_test.go
@@ -61,6 +61,7 @@ func TestClient_DescribeKubernetesClusters(t *testing.T) {
 		t.Logf("Cluster NodeCIDRMask %v", c.Parameters.NodeCIDRMask)
 		t.Logf("Cluster LoggingType %v", c.Parameters.LoggingType)
 		t.Logf("Cluster SLSProjectName %v", c.Parameters.SLSProjectName)
+		t.Logf("Cluster PublicSLB %v", c.Parameters.PublicSLB)
 
 		if c.MetaData.MultiAZ || c.MetaData.SubClass == "3az" {
 			t.Logf("%v is a MultiAZ kubernetes cluster", c.ClusterID)
@@ -164,6 +165,7 @@ func _TestCreateKubernetesCluster(t *testing.T) {
 		WorkerDataDisk:           true,
 		WorkerDataDiskCategory:   "cloud_efficiency",
 		WorkerDataDiskSize:       100,
+		PublicSLB:                true,
 		NodeCIDRMask:             "25",
 		LoggingType:              "SLS",
 		SLSProjectName:           "k8s-test-my-terraform-singleaz",


### PR DESCRIPTION
When creating a k8s cluster, setting bool to false will cause marshaled json ignore this bool, so I removed these 'omitempty'.

And I added PublicSLB to k8s creation and describe.