### PR TITLE
add SignedURLWithMethodForAssumeRole for Registry

### DIFF
--- a/oss/signature.go
+++ b/oss/signature.go
@@ -13,26 +13,44 @@ const HeaderOSSPrefix = "x-oss-"
 
 var ossParamsToSign = map[string]bool{
 	"acl":                          true,
+	"append":                       true,
+	"bucketInfo":                   true,
+	"cname":                        true,
+	"comp":                         true,
+	"cors":                         true,
 	"delete":                       true,
+	"endTime":                      true,
+	"img":                          true,
+	"lifecycle":                    true,
+	"live":                         true,
 	"location":                     true,
 	"logging":                      true,
-	"notification":                 true,
+	"objectMeta":                   true,
 	"partNumber":                   true,
-	"policy":                       true,
-	"requestPayment":               true,
-	"torrent":                      true,
-	"uploadId":                     true,
-	"uploads":                      true,
-	"versionId":                    true,
-	"versioning":                   true,
-	"versions":                     true,
-	"response-content-type":        true,
-	"response-content-language":    true,
-	"response-expires":             true,
+	"position":                     true,
+	"qos":                          true,
+	"referer":                      true,
+	"replication":                  true,
+	"replicationLocation":          true,
+	"replicationProgress":          true,
 	"response-cache-control":       true,
 	"response-content-disposition": true,
 	"response-content-encoding":    true,
-	"bucketInfo":                   true,
+	"response-content-language":    true,
+	"response-content-type":        true,
+	"response-expires":             true,
+	"security-token":               true,
+	"startTime":                    true,
+	"status":                       true,
+	"style":                        true,
+	"styleName":                    true,
+	"symlink":                      true,
+	"tagging":                      true,
+	"uploadId":                     true,
+	"uploads":                      true,
+	"vod":                          true,
+	"website":                      true,
+	"x-oss-process":                true,
 }
 
 func (client *Client) signRequest(request *request) {
@@ -62,7 +80,7 @@ func (client *Client) signRequest(request *request) {
 	}
 
 	if len(params) > 0 {
-		resource = resource + "?" + util.Encode(params)
+		resource = resource + "?" + util.EncodeWithoutEscape(params)
 	}
 
 	canonicalizedResource := resource
@@ -74,7 +92,7 @@ func (client *Client) signRequest(request *request) {
 	//log.Println("stringToSign: ", stringToSign)
 	signature := util.CreateSignature(stringToSign, client.AccessKeySecret)
 
-	if query.Get("OSSAccessKeyId") != "" {
+	if urlSignature {
 		query.Set("Signature", signature)
 	} else {
 		headers.Set("Authorization", "OSS "+client.AccessKeyId+":"+signature)

--- a/util/util.go
+++ b/util/util.go
@@ -4,13 +4,13 @@ import (
 	"bytes"
 	srand "crypto/rand"
 	"encoding/binary"
+	"encoding/json"
+	"fmt"
 	"math/rand"
 	"net/http"
 	"net/url"
 	"sort"
 	"time"
-	"fmt"
-	"encoding/json"
 )
 
 const dictionary = "_0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
@@ -60,6 +60,34 @@ func Encode(v url.Values) string {
 			if v != "" {
 				buf.WriteString("=")
 				buf.WriteString(url.QueryEscape(v))
+			}
+		}
+	}
+	return buf.String()
+}
+
+// Like Encode, but key and value are not escaped
+func EncodeWithoutEscape(v url.Values) string {
+	if v == nil {
+		return ""
+	}
+	var buf bytes.Buffer
+	keys := make([]string, 0, len(v))
+	for k := range v {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		vs := v[k]
+		prefix := k
+		for _, v := range vs {
+			if buf.Len() > 0 {
+				buf.WriteByte('&')
+			}
+			buf.WriteString(prefix)
+			if v != "" {
+				buf.WriteString("=")
+				buf.WriteString(v)
 			}
 		}
 	}
@@ -148,11 +176,10 @@ func GenerateRandomECSPassword() string {
 
 }
 
-
 func PrettyJson(object interface{}) string {
-	b,err := json.MarshalIndent(object,"", "    ")
+	b, err := json.MarshalIndent(object, "", "    ")
 	if err != nil {
-		fmt.Printf("ERROR: PrettyJson, %v\n %s\n",err,b)
+		fmt.Printf("ERROR: PrettyJson, %v\n %s\n", err, b)
 	}
 	return string(b)
 }


### PR DESCRIPTION
When we need SignedURL for AssumeRole, we need to pass STS Token in the URL, not in the header.
SignedURLWithMethodForAssumeRole will read the STS Token out, put it in the URL.
All params in ossParamsToSign are sub-resource, sub-resource should not be URL escaped.


See
https://help.aliyun.com/document_detail/31951.html
https://help.aliyun.com/document_detail/31952.html
https://help.aliyun.com/document_detail/31953.html

