### PR TITLE
add cdn auth utility

### DIFF
--- a/cdn/auth/random_uuid.go
+++ b/cdn/auth/random_uuid.go
@@ -1,0 +1,97 @@
+package auth
+
+import (
+	"crypto/rand"
+	"fmt"
+	"io"
+	"os"
+	"syscall"
+	"time"
+)
+
+const (
+	// Bits is the number of bits in a UUID
+	Bits = 128
+
+	// Size is the number of bytes in a UUID
+	Size = Bits / 8
+
+	format = "%08x%04x%04x%04x%012x"
+)
+
+var (
+	// Loggerf can be used to override the default logging destination. Such
+	// log messages in this library should be logged at warning or higher.
+	Loggerf = func(format string, args ...interface{}) {}
+)
+
+// UUID represents a UUID value. UUIDs can be compared and set to other values
+// and accessed by byte.
+type UUID [Size]byte
+
+// GenerateUUID creates a new, version 4 uuid.
+func GenerateUUID() (u UUID) {
+	const (
+		// ensures we backoff for less than 450ms total. Use the following to
+		// select new value, in units of 10ms:
+		// 	n*(n+1)/2 = d -> n^2 + n - 2d -> n = (sqrt(8d + 1) - 1)/2
+		maxretries = 9
+		backoff    = time.Millisecond * 10
+	)
+
+	var (
+		totalBackoff time.Duration
+		count        int
+		retries      int
+	)
+
+	for {
+		// This should never block but the read may fail. Because of this,
+		// we just try to read the random number generator until we get
+		// something. This is a very rare condition but may happen.
+		b := time.Duration(retries) * backoff
+		time.Sleep(b)
+		totalBackoff += b
+
+		n, err := io.ReadFull(rand.Reader, u[count:])
+		if err != nil {
+			if retryOnError(err) && retries < maxretries {
+				count += n
+				retries++
+				Loggerf("error generating version 4 uuid, retrying: %v", err)
+				continue
+			}
+
+			// Any other errors represent a system problem. What did someone
+			// do to /dev/urandom?
+			panic(fmt.Errorf("error reading random number generator, retried for %v: %v", totalBackoff.String(), err))
+		}
+
+		break
+	}
+
+	u[6] = (u[6] & 0x0f) | 0x40 // set version byte
+	u[8] = (u[8] & 0x3f) | 0x80 // set high order byte 0b10{8,9,a,b}
+
+	return u
+}
+
+func (u UUID) String() string {
+	return fmt.Sprintf(format, u[:4], u[4:6], u[6:8], u[8:10], u[10:])
+}
+
+// retryOnError tries to detect whether or not retrying would be fruitful.
+func retryOnError(err error) bool {
+	switch err := err.(type) {
+	case *os.PathError:
+		return retryOnError(err.Err) // unpack the target error
+	case syscall.Errno:
+		if err == syscall.EPERM {
+			// EPERM represents an entropy pool exhaustion, a condition under
+			// which we backoff and retry.
+			return true
+		}
+	}
+
+	return false
+}

--- a/cdn/auth/random_uuid_test.go
+++ b/cdn/auth/random_uuid_test.go
@@ -1,0 +1,21 @@
+package auth
+
+import (
+	"testing"
+)
+
+const iterations = 1000
+
+func TestUUID4Generation(t *testing.T) {
+	for i := 0; i < iterations; i++ {
+		u := GenerateUUID()
+
+		if u[6]&0xf0 != 0x40 {
+			t.Fatalf("version byte not correctly set: %v, %08b %08b", u, u[6], u[6]&0xf0)
+		}
+
+		if u[8]&0xc0 != 0x80 {
+			t.Fatalf("top order 8th byte not correctly set: %v, %b", u, u[8])
+		}
+	}
+}

--- a/cdn/auth/sign_url.go
+++ b/cdn/auth/sign_url.go
@@ -1,0 +1,80 @@
+package auth
+
+import (
+	"crypto/md5"
+	"fmt"
+	"net/url"
+	"time"
+)
+
+// An URLSigner provides URL signing utilities to sign URLs for Aliyun CDN
+// resources.
+// authentication document: https://help.aliyun.com/document_detail/85117.html
+type URLSigner struct {
+	authType string
+	privKey  string
+}
+
+// NewURLSigner returns a new signer object.
+func NewURLSigner(authType string, privKey string) *URLSigner {
+	return &URLSigner{
+		authType: authType,
+		privKey:  privKey,
+	}
+}
+
+// Sign returns a signed aliyuncdn url based on authentication type
+func (s URLSigner) Sign(uri string, expires time.Time) (string, error) {
+	r, err := url.Parse(uri)
+	if err != nil {
+		return "", fmt.Errorf("unable to parse url: %s", uri)
+	}
+
+	switch s.authType {
+	case "a":
+		return aTypeSign(r, s.privKey, expires), nil
+	case "b":
+		return bTypeSign(r, s.privKey, expires), nil
+	case "c":
+		return cTypeSign(r, s.privKey, expires), nil
+	default:
+		return "", fmt.Errorf("invalid authentication type")
+	}
+}
+
+// sign by A type authentication method.
+// authentication document: https://help.aliyun.com/document_detail/85113.html
+func aTypeSign(r *url.URL, privateKey string, expires time.Time) string {
+	//rand is a random uuid without "-"
+	rand := GenerateUUID().String()
+	// not use, "0" by default
+	uid := "0"
+	secret := fmt.Sprintf("%s-%d-%s-%s-%s", r.Path, expires.Unix(), rand, uid, privateKey)
+	hashValue := md5.Sum([]byte(secret))
+	authKey := fmt.Sprintf("%d-%s-%s-%x", expires.Unix(), rand, uid, hashValue)
+	if r.RawQuery == "" {
+		return fmt.Sprintf("%s?auth_key=%s", r.String(), authKey)
+	} else {
+		return fmt.Sprintf("%s&auth_key=%s", r.String(), authKey)
+	}
+}
+
+// sign by B type authentication method.
+// authentication document: https://help.aliyun.com/document_detail/85114.html
+func bTypeSign(r *url.URL, privateKey string, expires time.Time) string {
+	formatExp := expires.Format("200601021504")
+	secret := privateKey + formatExp + r.Path
+	hashValue := md5.Sum([]byte(secret))
+	signURL := fmt.Sprintf("%s://%s/%s/%x%s?%s", r.Scheme, r.Host, formatExp, hashValue, r.Path, r.RawQuery)
+	return signURL
+}
+
+// sign by C type authentication method.
+// authentication document: https://help.aliyun.com/document_detail/85115.html
+func cTypeSign(r *url.URL, privateKey string, expires time.Time) string {
+	hexExp := fmt.Sprintf("%x", expires.Unix())
+	secret := privateKey + r.Path + hexExp
+	hashValue := md5.Sum([]byte(secret))
+	signURL := fmt.Sprintf("%s://%s/%x/%s%s?%s", r.Scheme, r.Host, hashValue, hexExp, r.Path, r.RawQuery)
+	return signURL
+}

--- a/cdn/auth/sign_url.go
+++ b/cdn/auth/sign_url.go
@@ -54,9 +54,9 @@ func aTypeSign(r *url.URL, privateKey string, expires time.Time) string {
 	authKey := fmt.Sprintf("%d-%s-%s-%x", expires.Unix(), rand, uid, hashValue)
 	if r.RawQuery == "" {
 		return fmt.Sprintf("%s?auth_key=%s", r.String(), authKey)
-	} else {
-		return fmt.Sprintf("%s&auth_key=%s", r.String(), authKey)
 	}
+	return fmt.Sprintf("%s&auth_key=%s", r.String(), authKey)
+
 }
 
 // sign by B type authentication method.

--- a/cdn/auth/sign_url_test.go
+++ b/cdn/auth/sign_url_test.go
@@ -1,0 +1,54 @@
+package auth
+
+import (
+	"crypto/md5"
+	"fmt"
+	"net/url"
+	"reflect"
+	"testing"
+	"time"
+)
+
+var (
+	testSignTime = time.Unix(1541064730, 0)
+	testPrivKey  = "12345678"
+)
+
+func assertEqual(t *testing.T, x, y interface{}) {
+	if !reflect.DeepEqual(x, y) {
+		t.Errorf("%s: Not equal! Expected='%v', Actual='%v'\n", t.Name(), x, y)
+		t.FailNow()
+	}
+}
+
+func TestAtypeAuth(t *testing.T) {
+	r, _ := url.Parse("https://example.com/a?foo=bar")
+	url := aTypeTest(r, testPrivKey, testSignTime)
+	assertEqual(t, "https://example.com/a?foo=bar&auth_key=1541064730-0-0-f9dd5ed1e274ab4b1d5f5745344bf28b", url)
+}
+
+func TestBtypeAuth(t *testing.T) {
+	signer := newURLSigner("b", testPrivKey)
+	url, _ := signer.Sign("https://example.com/a?foo=bar", testSignTime)
+	assertEqual(t, "https://example.com/201811011732/3a19d83a89ccb00a73212420791b0123/a?foo=bar", url)
+}
+
+func TestCtypeAuth(t *testing.T) {
+	signer := newURLSigner("c", testPrivKey)
+	url, _ := signer.Sign("https://example.com/a?foo=bar", testSignTime)
+	assertEqual(t, "https://example.com/7d6b308ce87beb16d9dba32d741220f6/5bdac81a/a?foo=bar", url)
+}
+
+func aTypeTest(r *url.URL, privateKey string, expires time.Time) string {
+	//rand equals "0" in test case
+	rand := "0"
+	uid := "0"
+	secret := fmt.Sprintf("%s-%d-%s-%s-%s", r.Path, expires.Unix(), rand, uid, privateKey)
+	hashValue := md5.Sum([]byte(secret))
+	authKey := fmt.Sprintf("%d-%s-%s-%x", expires.Unix(), rand, uid, hashValue)
+	if r.RawQuery == "" {
+		return fmt.Sprintf("%s?auth_key=%s", r.String(), authKey)
+	} else {
+		return fmt.Sprintf("%s&auth_key=%s", r.String(), authKey)
+	}
+}

--- a/cdn/auth/sign_url_test.go
+++ b/cdn/auth/sign_url_test.go
@@ -14,9 +14,9 @@ var (
 	testPrivKey  = "12345678"
 )
 
-func assertEqual(t *testing.T, x, y interface{}) {
+func assertEqual(t *testing.T, name string, x, y interface{}) {
 	if !reflect.DeepEqual(x, y) {
-		t.Errorf("%s: Not equal! Expected='%v', Actual='%v'\n", t.Name(), x, y)
+		t.Errorf("%s: Not equal! Expected='%v', Actual='%v'\n", name, x, y)
 		t.FailNow()
 	}
 }
@@ -24,19 +24,19 @@ func assertEqual(t *testing.T, x, y interface{}) {
 func TestAtypeAuth(t *testing.T) {
 	r, _ := url.Parse("https://example.com/a?foo=bar")
 	url := aTypeTest(r, testPrivKey, testSignTime)
-	assertEqual(t, "https://example.com/a?foo=bar&auth_key=1541064730-0-0-f9dd5ed1e274ab4b1d5f5745344bf28b", url)
+	assertEqual(t, "testTypeA", "https://example.com/a?foo=bar&auth_key=1541064730-0-0-f9dd5ed1e274ab4b1d5f5745344bf28b", url)
 }
 
 func TestBtypeAuth(t *testing.T) {
 	signer := NewURLSigner("b", testPrivKey)
 	url, _ := signer.Sign("https://example.com/a?foo=bar", testSignTime)
-	assertEqual(t, "https://example.com/201811011732/3a19d83a89ccb00a73212420791b0123/a?foo=bar", url)
+	assertEqual(t, "testTypeB", "https://example.com/201811011732/3a19d83a89ccb00a73212420791b0123/a?foo=bar", url)
 }
 
 func TestCtypeAuth(t *testing.T) {
 	signer := NewURLSigner("c", testPrivKey)
 	url, _ := signer.Sign("https://example.com/a?foo=bar", testSignTime)
-	assertEqual(t, "https://example.com/7d6b308ce87beb16d9dba32d741220f6/5bdac81a/a?foo=bar", url)
+	assertEqual(t, "testTypeC", "https://example.com/7d6b308ce87beb16d9dba32d741220f6/5bdac81a/a?foo=bar", url)
 }
 
 func aTypeTest(r *url.URL, privateKey string, expires time.Time) string {

--- a/cdn/auth/sign_url_test.go
+++ b/cdn/auth/sign_url_test.go
@@ -48,7 +48,6 @@ func aTypeTest(r *url.URL, privateKey string, expires time.Time) string {
 	authKey := fmt.Sprintf("%d-%s-%s-%x", expires.Unix(), rand, uid, hashValue)
 	if r.RawQuery == "" {
 		return fmt.Sprintf("%s?auth_key=%s", r.String(), authKey)
-	} else {
-		return fmt.Sprintf("%s&auth_key=%s", r.String(), authKey)
 	}
+	return fmt.Sprintf("%s&auth_key=%s", r.String(), authKey)
 }

--- a/cdn/auth/sign_url_test.go
+++ b/cdn/auth/sign_url_test.go
@@ -28,13 +28,13 @@ func TestAtypeAuth(t *testing.T) {
 }
 
 func TestBtypeAuth(t *testing.T) {
-	signer := newURLSigner("b", testPrivKey)
+	signer := NewURLSigner("b", testPrivKey)
 	url, _ := signer.Sign("https://example.com/a?foo=bar", testSignTime)
 	assertEqual(t, "https://example.com/201811011732/3a19d83a89ccb00a73212420791b0123/a?foo=bar", url)
 }
 
 func TestCtypeAuth(t *testing.T) {
-	signer := newURLSigner("c", testPrivKey)
+	signer := NewURLSigner("c", testPrivKey)
 	url, _ := signer.Sign("https://example.com/a?foo=bar", testSignTime)
 	assertEqual(t, "https://example.com/7d6b308ce87beb16d9dba32d741220f6/5bdac81a/a?foo=bar", url)
 }


### PR DESCRIPTION
This PR enable Aliyun CDN user to sign url with A, B or C type auth method. Test cases refer to https://help.aliyun.com/document_detail/85116.html