### PR TITLE
fix: fix acm GBK decoding error due to aliyun changed respond encode

### DIFF
--- a/acm/acm.go
+++ b/acm/acm.go
@@ -1,17 +1,17 @@
 package acm
 
 import (
-	"net/http"
-	"time"
-	"fmt"
-	"errors"
-	"io/ioutil"
-	"strings"
-	"encoding/base64"
-	"crypto/sha1"
 	"crypto/hmac"
-	"strconv"
+	"crypto/sha1"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
 	"net/url"
+	"strconv"
+	"strings"
+	"time"
 )
 
 type Client struct {
@@ -148,11 +148,6 @@ func (c *Client) callApi(api string, params map[string]string, method string) (s
 		return "", err
 	}
 
-	byt, err = GbkToUtf8(byt)
-	if err != nil {
-		return "", err
-	}
-
 	body := string(byt)
 
 	if resp.StatusCode != 200 {
@@ -181,16 +176,12 @@ func (c *Client) GetAllConfigs(pageNo, pageSize int) (string, error) {
 }
 
 func (c *Client) Publish(dataId, group, content string) (string, error) {
-	bt, err := Utf8ToGbk([]byte(content))
-	if err != nil {
-		return "", err
-	}
 
 	return c.callApi("diamond-server/basestone.do?method=syncUpdateAll", map[string]string{
 		"tenant":  c.NameSpace,
 		"dataId":  dataId,
 		"group":   group,
-		"content": string(bt),
+		"content": content,
 	}, "POST")
 }
 

--- a/acm/acm_test.go
+++ b/acm/acm_test.go
@@ -26,7 +26,7 @@ func RunWithTest(t *testing.T, test func(client *Client, t *testing.T)) {
 	client := getClient()
 	defer client.Delete("test", "test")
 
-	_, err := client.Publish("test", "test", "test")
+	_, err := client.Publish("test", "test", "test测试")
 
 	if err != nil {
 		t.Fatalf("pulish error:%s", err)
@@ -49,6 +49,9 @@ func TestClient_GetConfig(t *testing.T) {
 		ret, err := client.GetConfig("test", "test")
 		if err != nil {
 			t.Error(err)
+		}
+		if ret != "test测试"{
+			t.Error("wrong respond content")
 		}
 		fmt.Println(ret)
 	})


### PR DESCRIPTION
Aliyun changed ACM service respond encoding format from GBK to UTF-8, this PR fixed the related issue and refined the unit test. 