### PR TITLE
fix parseBoolOrNil in cs

### DIFF
--- a/cs/clusters.go
+++ b/cs/clusters.go
@@ -371,21 +371,20 @@ func (client *Client) DescribeKubernetesCluster(id string) (cluster KubernetesCl
 	cluster.MetaData = metaData
 	cluster.RawMetaData = ""
 
-	parseBoolOrNil(cluster.Parameters.RawWorkerDataDisk, cluster.Parameters.WorkerDataDisk)
-	parseBoolOrNil(cluster.Parameters.RawPublicSLB, cluster.Parameters.PublicSLB)
-	parseBoolOrNil(cluster.Parameters.RawMasterAutoRenew, cluster.Parameters.MasterAutoRenew)
-	parseBoolOrNil(cluster.Parameters.RawWorkerAutoRenew, cluster.Parameters.WorkerAutoRenew)
+	cluster.Parameters.WorkerDataDisk = parseBoolOrNil(cluster.Parameters.RawWorkerDataDisk)
+	cluster.Parameters.PublicSLB = parseBoolOrNil(cluster.Parameters.RawPublicSLB)
+	cluster.Parameters.MasterAutoRenew = parseBoolOrNil(cluster.Parameters.RawMasterAutoRenew)
+	cluster.Parameters.WorkerAutoRenew = parseBoolOrNil(cluster.Parameters.RawWorkerAutoRenew)
 
 	return
 }
 
-func parseBoolOrNil(rawField string, field *bool) {
+func parseBoolOrNil(rawField string) *bool {
 	boolVal, err := strconv.ParseBool(rawField)
 	if err == nil {
-		field = &boolVal
-	} else {
-		field = nil
+		return &boolVal
 	}
+	return nil
 }
 
 type ClusterResizeArgs struct {

--- a/cs/clusters_test.go
+++ b/cs/clusters_test.go
@@ -78,7 +78,9 @@ func TestClient_DescribeKubernetesClusters(t *testing.T) {
 		t.Logf("Cluster NodeCIDRMask %v", c.Parameters.NodeCIDRMask)
 		t.Logf("Cluster LoggingType %v", c.Parameters.LoggingType)
 		t.Logf("Cluster SLSProjectName %v", c.Parameters.SLSProjectName)
-		t.Logf("Cluster PublicSLB %v", *c.Parameters.PublicSLB)
+		if c.Parameters.PublicSLB != nil {
+			t.Logf("Cluster PublicSLB %v", *c.Parameters.PublicSLB)
+		}
 
 		if c.MetaData.MultiAZ || c.MetaData.SubClass == "3az" {
 			t.Logf("%v is a MultiAZ kubernetes cluster", c.ClusterID)


### PR DESCRIPTION
The parseBoolOrNil is problematic, the second arg is a pointer, cannot be changed inside the function. So this function is not working at all.

Run the unit test again, saw it working now.