### PR TITLE
Add forced delete parameter

### DIFF
--- a/ecs/instances.go
+++ b/ecs/instances.go
@@ -464,6 +464,7 @@ func (client *Client) ModifyInstanceAutoReleaseTime(instanceId, time string) err
 
 type DeleteInstanceArgs struct {
 	InstanceId string
+	Force bool
 }
 
 type DeleteInstanceResponse struct {
@@ -473,8 +474,8 @@ type DeleteInstanceResponse struct {
 // DeleteInstance deletes instance
 //
 // You can read doc at http://docs.aliyun.com/#/pub/ecs/open-api/instance&deleteinstance
-func (client *Client) DeleteInstance(instanceId string) error {
-	args := DeleteInstanceArgs{InstanceId: instanceId}
+func (client *Client) DeleteInstance(instanceId string, forceDelete bool) error {
+	args := DeleteInstanceArgs{InstanceId: instanceId, Force: forceDelete}
 	response := DeleteInstanceResponse{}
 	err := client.Invoke("DeleteInstance", &args, &response)
 	return err


### PR DESCRIPTION
Because the instance status may be incorrect when deleting an instance, deleting the instance fails. Suggestion add Force delete parameter
 
