### PR TITLE
remove parameters and add scale api

### DIFF
--- a/cs/clusters.go
+++ b/cs/clusters.go
@@ -136,15 +136,17 @@ type KubernetesStackArgs struct {
 }
 
 type KubernetesCreationArgs struct {
-	DisableRollback bool   `json:"disable_rollback"`
-	Name            string `json:"name"`
-	TimeoutMins     int64  `json:"timeout_mins"`
-	ZoneId          string `json:"zoneid,omitempty"`
-	VPCID           string `json:"vpcid,omitempty"`
-	VSwitchId       string `json:"vswitchid,omitempty"`
-	ImageId         string `json:"image_id"`
-	ContainerCIDR   string `json:"container_cidr,omitempty"`
-	ServiceCIDR     string `json:"service_cidr,omitempty"`
+	DisableRollback bool     `json:"disable_rollback"`
+	Name            string   `json:"name"`
+	TimeoutMins     int64    `json:"timeout_mins"`
+	ZoneId          string   `json:"zoneid,omitempty"`
+	VPCID           string   `json:"vpcid,omitempty"`
+	RegionId        string   `json:"region_id,omitempty"`
+	VSwitchId       string   `json:"vswitchid,omitempty"`
+	VSwitchIds      []string `json:"vswitch_ids,omitempty"`
+	ImageId         string   `json:"image_id"`
+	ContainerCIDR   string   `json:"container_cidr,omitempty"`
+	ServiceCIDR     string   `json:"service_cidr,omitempty"`
 
 	MasterInstanceType       string           `json:"master_instance_type,omitempty"`
 	MasterSystemDiskSize     int64            `json:"master_system_disk_size,omitempty"`
@@ -157,6 +159,7 @@ type KubernetesCreationArgs struct {
 	MasterAutoRenewPeriod    int    `json:"master_auto_renew_period"`
 
 	WorkerInstanceType       string           `json:"worker_instance_type,omitempty"`
+	WorkerInstanceTypes      []string         `json:"worker_instance_types,omitempty"`
 	WorkerSystemDiskSize     int64            `json:"worker_system_disk_size,omitempty"`
 	WorkerSystemDiskCategory ecs.DiskCategory `json:"worker_system_disk_category,omitempty"`
 	WorkerDataDisk           bool             `json:"worker_data_disk"`
@@ -264,6 +267,7 @@ type KubernetesClusterMetaData struct {
 	SubClass          string `json:"SubClass"`
 }
 
+// deprecated
 type KubernetesClusterParameter struct {
 	ServiceCidr       string `json:"ServiceCIDR"`
 	ContainerCidr     string `json:"ContainerCIDR"`
@@ -371,20 +375,7 @@ func (client *Client) DescribeKubernetesCluster(id string) (cluster KubernetesCl
 	cluster.MetaData = metaData
 	cluster.RawMetaData = ""
 
-	cluster.Parameters.WorkerDataDisk = parseBoolOrNil(cluster.Parameters.RawWorkerDataDisk)
-	cluster.Parameters.PublicSLB = parseBoolOrNil(cluster.Parameters.RawPublicSLB)
-	cluster.Parameters.MasterAutoRenew = parseBoolOrNil(cluster.Parameters.RawMasterAutoRenew)
-	cluster.Parameters.WorkerAutoRenew = parseBoolOrNil(cluster.Parameters.RawWorkerAutoRenew)
-
 	return
-}
-
-func parseBoolOrNil(rawField string) *bool {
-	boolVal, err := strconv.ParseBool(rawField)
-	if err == nil {
-		return &boolVal
-	}
-	return nil
 }
 
 type ClusterResizeArgs struct {
@@ -406,7 +397,7 @@ func (client *Client) ResizeCluster(clusterID string, args *ClusterResizeArgs) e
 }
 
 // deprecated
-// use ResizeKubernetesCluster instead
+// use ScaleKubernetesCluster instead
 func (client *Client) ResizeKubernetes(clusterID string, args *KubernetesCreationArgs) error {
 	return client.Invoke("", http.MethodPut, "/clusters/"+clusterID, nil, args, nil)
 }
@@ -417,8 +408,9 @@ type KubernetesClusterResizeArgs struct {
 	LoginPassword   string `json:"login_password,omitempty"`
 
 	// Single AZ
-	WorkerInstanceType string `json:"worker_instance_type"`
-	NumOfNodes         int64  `json:"num_of_nodes"`
+	WorkerInstanceType  string   `json:"worker_instance_type"`
+	WorkerInstanceTypes []string `json:"worker_instance_types"`
+	NumOfNodes          int64    `json:"num_of_nodes"`
 
 	// Multi AZ
 	WorkerInstanceTypeA string `json:"worker_instance_type_a"`
@@ -429,8 +421,24 @@ type KubernetesClusterResizeArgs struct {
 	NumOfNodesC         int64  `json:"num_of_nodes_c"`
 }
 
+// deprecated
+// use ScaleKubernetesCluster instead
 func (client *Client) ResizeKubernetesCluster(clusterID string, args *KubernetesClusterResizeArgs) error {
 	return client.Invoke("", http.MethodPut, "/clusters/"+clusterID, nil, args, nil)
+}
+
+type KubernetesClusterScaleArgs struct {
+	LoginPassword            string           `json:"login_password,omitempty"`
+	KeyPair                  string           `json:"key_pair,omitempty"`
+	WorkerInstanceTypes      []string         `json:"worker_instance_types"`
+	WorkerSystemDiskSize     int64            `json:"worker_system_disk_size"`
+	WorkerSystemDiskCategory ecs.DiskCategory `json:"worker_system_disk_category"`
+	WorkerDataDisk           bool             `json:"worker_data_disk"`
+	Count                    int              `json:"count"`
+}
+
+func (client *Client) ScaleKubernetesCluster(clusterID string, args *KubernetesClusterScaleArgs) error {
+	return client.Invoke("", http.MethodPost, "/api/v2/clusters/"+clusterID, nil, args, nil)
 }
 
 func (client *Client) ModifyClusterName(clusterID, clusterName string) error {

--- a/cs/clusters_test.go
+++ b/cs/clusters_test.go
@@ -51,57 +51,15 @@ func TestClient_DescribeKubernetesClusters(t *testing.T) {
 			t.Errorf("Failed to DescribeCluster: %v", err)
 		}
 		t.Logf("Cluster Describe: %++v", c)
-		t.Logf("Cluster KeyPair %v", c.Parameters.KeyPair)
-		t.Logf("Cluster WorkerDataDisk %v", *c.Parameters.WorkerDataDisk)
-
-		t.Logf("Cluster MasterInstanceChargeType %v", c.Parameters.MasterInstanceChargeType)
-		if c.Parameters.MasterInstanceChargeType == "PrePaid" {
-			t.Logf("Cluster MasterAutoRenew %v", *c.Parameters.MasterAutoRenew)
-			t.Logf("Cluster MasterAutoRenewPeriod %v", c.Parameters.MasterAutoRenewPeriod)
-			t.Logf("Cluster MasterPeriod %v", c.Parameters.MasterPeriod)
-			t.Logf("Cluster MasterPeriodUnit %v", c.Parameters.MasterPeriodUnit)
-		}
-
-		t.Logf("Cluster WorkerInstanceChargeType %v", c.Parameters.WorkerInstanceChargeType)
-		if c.Parameters.WorkerInstanceChargeType == "PrePaid" {
-			t.Logf("Cluster WorkerAutoRenew %v", *c.Parameters.WorkerAutoRenew)
-			t.Logf("Cluster WorkerAutoRenewPeriod %v", c.Parameters.WorkerAutoRenewPeriod)
-			t.Logf("Cluster WorkerPeriod %v", c.Parameters.WorkerPeriod)
-			t.Logf("Cluster WorkerPeriodUnit %v", c.Parameters.WorkerPeriodUnit)
-		}
-
-		if c.Parameters.WorkerDataDisk != nil && *c.Parameters.WorkerDataDisk {
-			t.Logf("Cluster WorkerDataDiskSize %v", c.Parameters.WorkerDataDiskSize)
-			t.Logf("Cluster WorkerDataDiskCategory %v", c.Parameters.WorkerDataDiskCategory)
-		}
-		t.Logf("Cluster ImageId %v", c.Parameters.ImageId)
-		t.Logf("Cluster NodeCIDRMask %v", c.Parameters.NodeCIDRMask)
-		t.Logf("Cluster LoggingType %v", c.Parameters.LoggingType)
-		t.Logf("Cluster SLSProjectName %v", c.Parameters.SLSProjectName)
-		if c.Parameters.PublicSLB != nil {
-			t.Logf("Cluster PublicSLB %v", *c.Parameters.PublicSLB)
-		}
 
 		if c.MetaData.MultiAZ || c.MetaData.SubClass == "3az" {
 			t.Logf("%v is a MultiAZ kubernetes cluster", c.ClusterID)
-			t.Logf("Cluster VSWA ID %v", c.Parameters.VSwitchIdA)
-			t.Logf("Cluster VSWB ID %v", c.Parameters.VSwitchIdB)
-			t.Logf("Cluster VSWC ID %v", c.Parameters.VSwitchIdC)
-			t.Logf("Cluster MasterInstanceTypeA %v", c.Parameters.MasterInstanceTypeA)
-			t.Logf("Cluster MasterInstanceTypeB %v", c.Parameters.MasterInstanceTypeB)
-			t.Logf("Cluster MasterInstanceTypeC %v", c.Parameters.MasterInstanceTypeC)
-			t.Logf("Cluster NumOfNodeA %v", c.Parameters.NumOfNodesA)
-			t.Logf("Cluster NumOfNodeB %v", c.Parameters.NumOfNodesB)
-			t.Logf("Cluster NumOfNodeC %v", c.Parameters.NumOfNodesC)
 		} else {
 			if cluster.ClusterType == "ManagedKubernetes" {
 				t.Logf("%v is a Managed kubernetes cluster", c.ClusterID)
 			} else {
 				t.Logf("%v is a SingleAZ kubernetes cluster", c.ClusterID)
 			}
-			t.Logf("Cluster VSW ID %v", c.Parameters.VSwitchID)
-			t.Logf("Cluster MasterInstanceType %v", c.Parameters.MasterInstanceType)
-			t.Logf("Cluster NumOfNode %v", c.Parameters.NumOfNodes)
 		}
 	}
 }
@@ -312,19 +270,22 @@ func _TestCreateKubernetesMultiAZCluster(t *testing.T) {
 	t.Logf("Cluster: %++v", cluster)
 }
 
-func _TestResizeKubernetesCluster(t *testing.T) {
+func TestScaleKubernetesCluster(t *testing.T) {
+	// Comment below to test
+	t.SkipNow()
+
 	client := NewTestClientForDebug()
 
-	args := KubernetesClusterResizeArgs{
-		DisableRollback:    true,
-		TimeoutMins:        60,
-		LoginPassword:      "test-password123",
-		WorkerInstanceType: "ecs.sn1ne.large",
-		NumOfNodes:         2,
+	args := KubernetesClusterScaleArgs{
+		LoginPassword:            "test-password123",
+		WorkerInstanceTypes:      []string{"ecs.sn1ne.large"},
+		WorkerSystemDiskCategory: "cloud_ssd",
+		WorkerSystemDiskSize:     int64(40),
+		Count:                    2,
 	}
 
-	err := client.ResizeKubernetesCluster("c3419330390a94906bcacc55bfa9dd21f", &args)
+	err := client.ScaleKubernetesCluster("c3419330390a94906bcacc55bfa9dd21f", &args)
 	if err != nil {
-		t.Fatalf("Failed to TestResizeKubernetesCluster: %v", err)
+		t.Fatalf("Failed to TestScaleKubernetesCluster: %v", err)
 	}
 }


### PR DESCRIPTION
Container Service no longer returns Parameters when describing a cluster, so aliyungo should not read from Parameters any more.

WorkerInstanceTypes and VSwitchIds is added when creating a new cluster.

And a new ScaleKubernetesCluster function is added.

Signed-off-by: xh4n3 <xyn1016@gmail.com>