### PR TITLE
Support SourceCIDR field to CreateSnatEntry

### DIFF
--- a/ecs/snat_entry.go
+++ b/ecs/snat_entry.go
@@ -7,6 +7,7 @@ type CreateSnatEntryArgs struct {
 	SnatTableId     string
 	SourceVSwitchId string
 	SnatIp          string
+	SourceCIDR      string
 }
 
 type CreateSnatEntryResponse struct {

--- a/ecs/snat_entry_test.go
+++ b/ecs/snat_entry_test.go
@@ -14,3 +14,18 @@ func TestDescribeSnatTableEntry(t *testing.T) {
 		t.Fatalf("Failed to DescribeBandwidthPackages: %v", err)
 	}
 }
+
+func TestCreateSnatEntryWithSourceCIDR(t *testing.T) {
+	client := NewTestClient()
+	args := CreateSnatEntryArgs{
+		RegionId:    "cn-beijing",
+		SnatTableId: "stb-xxx",
+		SnatIp:      "47.XX.XX.98",
+		SourceCIDR:  "192.168.1.1/32",
+	}
+
+	_, err := client.CreateSnatEntry(&args)
+	if err != nil {
+		t.Errorf("failed to CreateSnatEntry with SourceCIDR: %v", err)
+	}
+}


### PR DESCRIPTION
try to support SourceCIDR field to CreateSnatEntry, ref to [official docs](https://help.aliyun.com/document_detail/120259.html?spm=a2c4g.11186623.6.612.599c4078PDkIPn) .
