### PR TITLE
Add SetTransport method for other Client structs

### DIFF
--- a/cms/client.go
+++ b/cms/client.go
@@ -33,6 +33,14 @@ func (client *Client) SetDebug(debug bool) {
 	client.debug = debug
 }
 
+// SetTransport sets transport to the http client
+func (client *Client) SetTransport(transport http.RoundTripper) {
+	if client.httpClient == nil {
+		client.httpClient = &http.Client{}
+	}
+	client.httpClient.Transport = transport
+}
+
 const (
 	//TODO 旧的API，暂时保留
 	DefaultEndpoint = "http://alert.aliyuncs.com"

--- a/cs/client.go
+++ b/cs/client.go
@@ -81,6 +81,14 @@ func (client *Client) SetEndpoint(endpoint string) {
 	client.endpoint = endpoint
 }
 
+// SetTransport sets transport to the http client
+func (client *Client) SetTransport(transport http.RoundTripper) {
+	if client.httpClient == nil {
+		client.httpClient = &http.Client{}
+	}
+	client.httpClient.Transport = transport
+}
+
 type Request struct {
 	Method          string
 	URL             string

--- a/cs/projects_client.go
+++ b/cs/projects_client.go
@@ -67,6 +67,14 @@ func (client *ProjectClient) SetUserAgent(userAgent string) {
 	client.userAgent = userAgent
 }
 
+// SetTransport sets transport to the http client
+func (client *ProjectClient) SetTransport(transport http.RoundTripper) {
+	if client.httpClient == nil {
+		client.httpClient = &http.Client{}
+	}
+	client.httpClient.Transport = transport
+}
+
 func (client *ProjectClient) ClusterId() string {
 	return client.clusterId
 }

--- a/mns/client.go
+++ b/mns/client.go
@@ -22,6 +22,14 @@ func (client *Client) SetDebug(debug bool) {
 	client.debug = debug
 }
 
+// SetTransport sets transport to the http client
+func (client *Client) SetTransport(transport http.RoundTripper) {
+	if client.httpClient == nil {
+		client.httpClient = &http.Client{}
+	}
+	client.httpClient.Transport = transport
+}
+
 func NewClient(accessKeyId, accessKeySecret, endpoint string) (client *Client) {
 	client = &Client{
 		AccessKeyId:     accessKeyId,

--- a/oss/client.go
+++ b/oss/client.go
@@ -37,6 +37,7 @@ type Client struct {
 	Internal        bool
 	Secure          bool
 	ConnectTimeout  time.Duration
+	Transport       http.RoundTripper
 
 	endpoint string
 	debug    bool
@@ -1188,6 +1189,9 @@ func (client *Client) run(req *request, resp interface{}) (*http.Response, error
 			Proxy: http.ProxyFromEnvironment,
 		},
 		Timeout: req.timeout,
+	}
+	if client.Transport != nil {
+		c.Transport = client.Transport
 	}
 
 	return client.doHttpRequest(c, hreq, resp)

--- a/ros/client.go
+++ b/ros/client.go
@@ -86,6 +86,14 @@ func (client *Client) SetSecurityToken(securityToken string) {
 	client.SecurityToken = securityToken
 }
 
+// SetTransport sets transport to the http client
+func (client *Client) SetTransport(transport http.RoundTripper) {
+	if client.httpClient == nil {
+		client.httpClient = &http.Client{}
+	}
+	client.httpClient.Transport = transport
+}
+
 type Request struct {
 	Method          string
 	URL             string

--- a/sls/client.go
+++ b/sls/client.go
@@ -28,6 +28,14 @@ func (client *Client) SetDebug(debug bool) {
 	client.debug = debug
 }
 
+// SetTransport sets transport to the http client
+func (client *Client) SetTransport(transport http.RoundTripper) {
+	if client.httpClient == nil {
+		client.httpClient = &http.Client{}
+	}
+	client.httpClient.Transport = transport
+}
+
 type Project struct {
 	client      *Client
 	Name        string `json:"projectName,omitempty"`


### PR DESCRIPTION
Use this method to give users more control of httpClient. #369 