### PR TITLE
modify tags for SecurityGroupId field in ModifyNetworkInterfaceAttributeArgs

### DIFF
--- a/ecs/eni.go
+++ b/ecs/eni.go
@@ -104,7 +104,7 @@ type DetachNetworkInterfaceResponse common.Response
 type ModifyNetworkInterfaceAttributeArgs struct {
 	RegionId             common.Region
 	NetworkInterfaceId   string
-	SecurityGroupId      []string
+	SecurityGroupId      []string `query:"list"`
 	NetworkInterfaceName string
 	Description          string
 }
@@ -122,7 +122,7 @@ type AssignPrivateIpAddressesArgs struct {
 	RegionId                       common.Region
 	NetworkInterfaceId             string
 	PrivateIpAddress               []string `query:"list"` // optional
-	SecondaryPrivateIpAddressCount int      // optional
+	SecondaryPrivateIpAddressCount int                     // optional
 }
 
 type AssignPrivateIpAddressesResponse common.Response

--- a/ecs/eni_test.go
+++ b/ecs/eni_test.go
@@ -74,3 +74,17 @@ func TestUnAssignPrivateIPAddresses(t *testing.T) {
 		t.Errorf("Failed to UnAssignPrivateIpAddresses: %v", err)
 	}
 }
+
+func TestModifyNetworkInterfaceAttribute(t *testing.T) {
+	args := &ModifyNetworkInterfaceAttributeArgs{
+		RegionId:           common.Shanghai,
+		NetworkInterfaceId: "eni-testeni",
+		SecurityGroupId:    []string{"sg-xxx", "sg-yyy"},
+	}
+
+	client := NewTestClient()
+	_, err := client.ModifyNetworkInterfaceAttribute(args)
+	if err != nil {
+		t.Errorf("failed to ModifyNetworkInterfaceAttribute: %v", err)
+	}
+}


### PR DESCRIPTION
ref to [docs](https://help.aliyun.com/document_detail/58513.html?spm=a2c4g.11174283.6.1350.738e52fed8Wlf4)

SecurityGroupId field should have `query:"list"` tag to avoid to be marshaled to a json string slice.

Signed-off-by: Bruce Ma <brucema19901024@gmail.com>