### PR TITLE
Add edge kubernetes related params to support scaling Alicloud ENS node

### DIFF
--- a/cs/clusters.go
+++ b/cs/clusters.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 
 	"encoding/json"
+
 	"github.com/denverdino/aliyungo/common"
 	"github.com/denverdino/aliyungo/ecs"
 )
@@ -451,6 +452,11 @@ type KubernetesClusterScaleArgs struct {
 	WorkerSystemDiskCategory ecs.DiskCategory `json:"worker_system_disk_category"`
 	WorkerDataDisk           bool             `json:"worker_data_disk"`
 	Count                    int              `json:"count"`
+
+	// Edge worker related args
+	IsEdgeWorker          bool   `json:"is_edge_worker"`
+	EnsRegionId           string `json:"ens_region_id"`
+	EnsInternetChargeType string `json:"ens_internet_charge_type"`
 
 	//data disk
 	WorkerDataDiskCategory  string `json:"worker_data_disk_category"`


### PR DESCRIPTION
Add three edge kubernetes related params to support scaling Alicloud ENS node as worker into edge cluster.