### PR TITLE
include x-oss-traffic-limit in url signature

### DIFF
--- a/oss/signature.go
+++ b/oss/signature.go
@@ -51,6 +51,7 @@ var ossParamsToSign = map[string]bool{
 	"vod":                          true,
 	"website":                      true,
 	"x-oss-process":                true,
+	"x-oss-traffic-limit":          true,
 }
 
 func (client *Client) signRequest(request *request) {


### PR DESCRIPTION
Traffic limitings in OSS SignedURL are not currently supported in aliyungo, we should allow `x-oss-traffic-limit` to be included in url params signature calculation.

See https://help.aliyun.com/document_detail/124583.html
