### PR TITLE
support AssignPrivateIpAddresses in sync mode

### DIFF
--- a/ecs/eni.go
+++ b/ecs/eni.go
@@ -129,7 +129,16 @@ type AssignPrivateIpAddressesArgs struct {
 	SecondaryPrivateIpAddressCount int      // optional
 }
 
-type AssignPrivateIpAddressesResponse common.Response
+type AssignPrivateIpAddressesResponse struct {
+	common.Response
+
+	AssignedPrivateIpAddressesSet struct {
+		NetworkInterfaceId string
+		PrivateIpSet       struct {
+			PrivateIpAddress []string
+		}
+	}
+}
 
 func (client *Client) CreateNetworkInterface(args *CreateNetworkInterfaceArgs) (resp *CreateNetworkInterfaceResponse, err error) {
 	resp = &CreateNetworkInterfaceResponse{}

--- a/ecs/eni_test.go
+++ b/ecs/eni_test.go
@@ -13,9 +13,13 @@ func TestAssignPrivateIPAddresses(t *testing.T) {
 		PrivateIpAddress:   []string{"192.168.1.200", "192.168.1.201"},
 	}
 	client := NewTestClient()
-	_, err := client.AssignPrivateIpAddresses(&req)
+	assignPrivateIpAddressesResponse, err := client.AssignPrivateIpAddresses(&req)
 	if err != nil {
 		t.Errorf("Failed to AssignPrivateIpAddresses: %v", err)
+	}
+
+	if assignPrivateIpAddressesResponse.AssignedPrivateIpAddressesSet.NetworkInterfaceId != "eni-testeni" {
+		t.Errorf("assert network id mismatch.%s\n", assignPrivateIpAddressesResponse.AssignedPrivateIpAddressesSet.NetworkInterfaceId)
 	}
 
 	time.Sleep(5 * time.Second)


### PR DESCRIPTION
`AssignPrivateIpAddresses` in ECS is now return `AssignedPrivateIpAddressesSet`
See https://help.aliyun.com/document_detail/85917.html