### PR TITLE
add loginAsNonRoot in replaceSystemDisk

### DIFF
--- a/ecs/disks.go
+++ b/ecs/disks.go
@@ -80,7 +80,6 @@ type DescribeDisksArgs struct {
 	common.Pagination
 }
 
-//
 // You can read doc at http://docs.aliyun.com/#/pub/ecs/open-api/datatype&diskitemtype
 type DiskItemType struct {
 	DiskId             string
@@ -269,7 +268,6 @@ type ResizeDiskResponse struct {
 	common.Response
 }
 
-//
 // ResizeDisk can only support to enlarge disk size
 // You can read doc at https://help.aliyun.com/document_detail/25522.html
 func (client *Client) ResizeDisk(diskId string, sizeGB int) error {
@@ -327,10 +325,11 @@ func (client *Client) ModifyDiskAttribute(args *ModifyDiskAttributeArgs) error {
 }
 
 type ReplaceSystemDiskArgs struct {
-	InstanceId  string
-	ImageId     string
-	SystemDisk  SystemDiskType
-	ClientToken string
+	InstanceId     string
+	ImageId        string
+	SystemDisk     SystemDiskType
+	ClientToken    string
+	LoginAsNonRoot bool
 }
 
 type ReplaceSystemDiskResponse struct {

--- a/ecs/disks_test.go
+++ b/ecs/disks_test.go
@@ -152,6 +152,23 @@ func TestReplaceSystemDisk(t *testing.T) {
 	t.Logf("Replace system disk %s successfully ", diskId)
 }
 
+func TestReplaceSystemDiskWithLoginAsNonRoot(t *testing.T) {
+	client := NewTestClientForDebug()
+
+	args := ReplaceSystemDiskArgs{
+		InstanceId:     TestInstanceId,
+		ImageId:        TestImageId,
+		LoginAsNonRoot: true,
+	}
+
+	diskId, err := client.ReplaceSystemDisk(&args)
+	if err != nil {
+		t.Errorf("Failed to replace system disk %v", err)
+	} else {
+		t.Logf("diskId is %s", diskId)
+	}
+}
+
 func TestResizeDisk(t *testing.T) {
 	accessKeyId := os.Getenv("ACCESS_KEY_ID")
 	accessKeySecret := os.Getenv("ACCESS_KEY_SECRET")


### PR DESCRIPTION
The interface `ReplaceSystemDisk` support loginAsNonRoot, this change add it into args.